### PR TITLE
Pin GitHub Action to commit hash for security

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
           fi
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           files: build/${{ env.APP_NAME }}.zip
 


### PR DESCRIPTION
- Pin `softprops/action-gh-release` to commit hash `a06a81a03ee405af7f2048a818ed3f03bbf83c7b` instead of tag `v2` to prevent potential supply chain attacks