### PR TITLE
Show Updates section only in App Store Connect builds

### DIFF
--- a/AgentUsage/Views/SettingsView.swift
+++ b/AgentUsage/Views/SettingsView.swift
@@ -24,11 +24,13 @@ struct SettingsView: View {
                     Label("Notifications", systemImage: "bell")
                 }
 
-            UpdatesTab()
-                .environmentObject(updaterController)
-                .tabItem {
-                    Label("Updates", systemImage: "arrow.triangle.2.circlepath")
-                }
+            if Bundle.main.isAppStoreBuild {
+                UpdatesTab()
+                    .environmentObject(updaterController)
+                    .tabItem {
+                        Label("Updates", systemImage: "arrow.triangle.2.circlepath")
+                    }
+            }
 
             AboutTab()
                 .tabItem {
@@ -251,6 +253,14 @@ extension Bundle {
         let version = infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
         let build = infoDictionary?["CFBundleVersion"] as? String ?? "1"
         return "\(version) (\(build))"
+    }
+
+    /// True only when distributed through App Store Connect (Mac App Store or
+    /// TestFlight), detected by the presence of an App Store receipt.
+    /// Developer ID / direct-download / ad-hoc / dev builds have no receipt.
+    var isAppStoreBuild: Bool {
+        guard let receiptURL = appStoreReceiptURL else { return false }
+        return FileManager.default.fileExists(atPath: receiptURL.path)
     }
 }
 

--- a/AgentUsage/macOS/Views/SettingsTabView.swift
+++ b/AgentUsage/macOS/Views/SettingsTabView.swift
@@ -390,89 +390,91 @@ struct SettingsTabView: View {
                 }
                 #endif
 
-                // Updates Section
-                settingsCard(title: "Updates", systemImage: "arrow.down.circle") {
-                    VStack(spacing: 12) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Current Version")
-                                    .font(.body)
-                                Text("Installed app version")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            Text(Bundle.main.appVersion)
-                                .font(.body.monospaced())
-                                .foregroundStyle(.secondary)
-                        }
-
-                        Divider()
-
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Automatic Updates")
-                                    .font(.body)
-                                Text("Check for updates automatically")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            Toggle("", isOn: Binding(
-                                get: { updaterController.automaticallyChecksForUpdates },
-                                set: { updaterController.automaticallyChecksForUpdates = $0 }
-                            ))
-                            .labelsHidden()
-                        }
-
-                        Divider()
-
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Check for Updates")
-                                    .font(.body)
-                                Text("Download and install the latest version")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-
-                            if let result = updaterController.lastCheckResult {
-                                HStack(spacing: 4) {
-                                    Image(systemName: result.systemImage)
-                                        .foregroundStyle(resultColor(for: result))
-                                    Text(result.message)
+                // Updates Section (App Store Connect builds only)
+                if Bundle.main.isAppStoreBuild {
+                    settingsCard(title: "Updates", systemImage: "arrow.down.circle") {
+                        VStack(spacing: 12) {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Current Version")
+                                        .font(.body)
+                                    Text("Installed app version")
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
-                                        .lineLimit(1)
                                 }
-                            }
-
-                            if updaterController.isChecking {
-                                ProgressView()
-                                    .controlSize(.small)
-                            } else {
-                                Button("Check Now") {
-                                    updaterController.checkForUpdates()
-                                }
-                                .disabled(!updaterController.canCheckForUpdates)
-                            }
-                        }
-
-                        Divider()
-
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Last Checked")
-                                    .font(.body)
-                                Text("Most recent update check")
-                                    .font(.caption)
+                                Spacer()
+                                Text(Bundle.main.appVersion)
+                                    .font(.body.monospaced())
                                     .foregroundStyle(.secondary)
                             }
-                            Spacer()
-                            Text(updaterController.lastCheckDescription)
-                                .font(.body)
-                                .foregroundStyle(.secondary)
+
+                            Divider()
+
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Automatic Updates")
+                                        .font(.body)
+                                    Text("Check for updates automatically")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Toggle("", isOn: Binding(
+                                    get: { updaterController.automaticallyChecksForUpdates },
+                                    set: { updaterController.automaticallyChecksForUpdates = $0 }
+                                ))
+                                .labelsHidden()
+                            }
+
+                            Divider()
+
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Check for Updates")
+                                        .font(.body)
+                                    Text("Download and install the latest version")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+
+                                if let result = updaterController.lastCheckResult {
+                                    HStack(spacing: 4) {
+                                        Image(systemName: result.systemImage)
+                                            .foregroundStyle(resultColor(for: result))
+                                        Text(result.message)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(1)
+                                    }
+                                }
+
+                                if updaterController.isChecking {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                } else {
+                                    Button("Check Now") {
+                                        updaterController.checkForUpdates()
+                                    }
+                                    .disabled(!updaterController.canCheckForUpdates)
+                                }
+                            }
+
+                            Divider()
+
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Last Checked")
+                                        .font(.body)
+                                    Text("Most recent update check")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Text(updaterController.lastCheckDescription)
+                                    .font(.body)
+                                    .foregroundStyle(.secondary)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Hides the Settings **Updates** section unless the app is an App Store Connect (ASC) build — i.e. distributed via the Mac App Store or TestFlight. It stays hidden in Developer ID / direct-download, ad-hoc, and local dev builds.

## Changes

- **`Bundle.isAppStoreBuild`** (new): runtime check for the presence of an App Store receipt (`appStoreReceiptURL` + `FileManager.fileExists`). Returns `true` only for Mac App Store / TestFlight builds, which are the only channels that carry a receipt. Added to the existing `Bundle` extension in `SettingsView.swift`.
- **Gated both render sites** behind `if Bundle.main.isAppStoreBuild`:
  - `AgentUsage/Views/SettingsView.swift` — the `UpdatesTab` in the classic `Settings` scene TabView.
  - `AgentUsage/macOS/Views/SettingsTabView.swift` — the "Updates" card in the main-window Settings tab.

## Out of scope

- The `#if DEBUG` "Force Background Check" control and the menu-bar / dashboard "update available" badges are untouched (not part of the Updates section).

## Verification

- `xcodebuild ... -scheme AgentUsage -configuration Debug build` → **BUILD SUCCEEDED**.
- Confirmed the built Debug app carries no `_MASReceipt/receipt`, so `isAppStoreBuild` evaluates to `false` and the section is hidden — the intended non-ASC behavior. A genuine ASC build (with a receipt) shows the section; that path is only verifiable via TestFlight/App Store.

https://claude.ai/code/session_01JUEWPAdpjPWLZov7dxxsio