### PR TITLE
ci: comment out GitHub Actions workflows superseded by Xcode Cloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,100 +1,111 @@
-name: CI
+# ============================================================================
+# DISABLED: CI
+#
+# CI, build, and release/distribution moved to Xcode Cloud
+# (build / test / archive -> App Store Connect). This workflow is intentionally
+# commented out rather than deleted so the original definition is preserved.
+#
+# To restore: uncomment the block below and, if it was disabled on GitHub,
+# re-enable it with `gh workflow enable "CI"`.
+# ============================================================================
 
-on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - ".beads/**"
-      - ".claude/**"
-  workflow_dispatch:
-
-permissions:
-  contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-jobs:
-  macos:
-    name: macOS Build & Test
-    runs-on: macos-26
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - parallel:
-          - name: Test AgentUsageKit package
-            run: swift test --package-path AgentUsageKit
-
-          - name: Test release tooling
-            run: |
-              .github/scripts/tests/test-compute-version.sh
-              .github/scripts/tests/test-release-gate.sh
-              .github/scripts/tests/test-release-destinations.sh
-              .github/scripts/tests/test-appcast-generation.sh
-
-          - name: Build macOS app
-            run: |
-              xcodebuild -project AgentUsage.xcodeproj \
-                -scheme AgentUsage \
-                -configuration Debug \
-                -destination 'platform=macOS' \
-                -derivedDataPath build/DerivedData \
-                build \
-                CODE_SIGN_IDENTITY="-" \
-                CODE_SIGNING_REQUIRED=NO
-
-      - name: Test macOS app
-        run: |
-          xcodebuild -project AgentUsage.xcodeproj \
-            -scheme AgentUsage \
-            -configuration Debug \
-            -destination 'platform=macOS' \
-            -derivedDataPath build/DerivedData \
-            test \
-            CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_REQUIRED=NO
-
-  ios:
-    name: iOS & Widgets Build
-    runs-on: macos-26
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Resolve Swift package dependencies
-        run: |
-          xcodebuild -resolvePackageDependencies \
-            -project AgentUsage.xcodeproj \
-            -clonedSourcePackagesDirPath build/SourcePackages
-
-      - parallel:
-          - name: Build iOS app and test bundles
-            run: |
-              xcodebuild -project AgentUsage.xcodeproj \
-                -scheme AgentUsage \
-                -configuration Debug \
-                -destination 'generic/platform=iOS Simulator' \
-                -derivedDataPath build/DerivedData-iOS \
-                -clonedSourcePackagesDirPath build/SourcePackages \
-                build-for-testing \
-                CODE_SIGN_IDENTITY="-" \
-                CODE_SIGNING_REQUIRED=NO
-
-          - name: Build widgets
-            run: |
-              xcodebuild -project AgentUsage.xcodeproj \
-                -scheme AgentUsageWidgetsExtension \
-                -configuration Debug \
-                -destination 'generic/platform=iOS Simulator' \
-                -derivedDataPath build/DerivedData-widgets \
-                -clonedSourcePackagesDirPath build/SourcePackages \
-                build \
-                CODE_SIGN_IDENTITY="-" \
-                CODE_SIGNING_REQUIRED=NO
+# name: CI
+#
+# on:
+#   pull_request:
+#     branches: [main]
+#   push:
+#     branches: [main]
+#     paths-ignore:
+#       - "**/*.md"
+#       - ".beads/**"
+#       - ".claude/**"
+#   workflow_dispatch:
+#
+# permissions:
+#   contents: read
+#
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
+#
+# jobs:
+#   macos:
+#     name: macOS Build & Test
+#     runs-on: macos-26
+#
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - parallel:
+#           - name: Test AgentUsageKit package
+#             run: swift test --package-path AgentUsageKit
+#
+#           - name: Test release tooling
+#             run: |
+#               .github/scripts/tests/test-compute-version.sh
+#               .github/scripts/tests/test-release-gate.sh
+#               .github/scripts/tests/test-release-destinations.sh
+#               .github/scripts/tests/test-appcast-generation.sh
+#
+#           - name: Build macOS app
+#             run: |
+#               xcodebuild -project AgentUsage.xcodeproj \
+#                 -scheme AgentUsage \
+#                 -configuration Debug \
+#                 -destination 'platform=macOS' \
+#                 -derivedDataPath build/DerivedData \
+#                 build \
+#                 CODE_SIGN_IDENTITY="-" \
+#                 CODE_SIGNING_REQUIRED=NO
+#
+#       - name: Test macOS app
+#         run: |
+#           xcodebuild -project AgentUsage.xcodeproj \
+#             -scheme AgentUsage \
+#             -configuration Debug \
+#             -destination 'platform=macOS' \
+#             -derivedDataPath build/DerivedData \
+#             test \
+#             CODE_SIGN_IDENTITY="-" \
+#             CODE_SIGNING_REQUIRED=NO
+#
+#   ios:
+#     name: iOS & Widgets Build
+#     runs-on: macos-26
+#
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Resolve Swift package dependencies
+#         run: |
+#           xcodebuild -resolvePackageDependencies \
+#             -project AgentUsage.xcodeproj \
+#             -clonedSourcePackagesDirPath build/SourcePackages
+#
+#       - parallel:
+#           - name: Build iOS app and test bundles
+#             run: |
+#               xcodebuild -project AgentUsage.xcodeproj \
+#                 -scheme AgentUsage \
+#                 -configuration Debug \
+#                 -destination 'generic/platform=iOS Simulator' \
+#                 -derivedDataPath build/DerivedData-iOS \
+#                 -clonedSourcePackagesDirPath build/SourcePackages \
+#                 build-for-testing \
+#                 CODE_SIGN_IDENTITY="-" \
+#                 CODE_SIGNING_REQUIRED=NO
+#
+#           - name: Build widgets
+#             run: |
+#               xcodebuild -project AgentUsage.xcodeproj \
+#                 -scheme AgentUsageWidgetsExtension \
+#                 -configuration Debug \
+#                 -destination 'generic/platform=iOS Simulator' \
+#                 -derivedDataPath build/DerivedData-widgets \
+#                 -clonedSourcePackagesDirPath build/SourcePackages \
+#                 build \
+#                 CODE_SIGN_IDENTITY="-" \
+#                 CODE_SIGNING_REQUIRED=NO

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,47 +1,58 @@
-# Deploys the gh-pages branch (which holds appcast.xml, the Sparkle update feed)
-# to the live GitHub Pages site.
+# ============================================================================
+# DISABLED: Deploy appcast to Pages
 #
-# Why Pages source is "GitHub Actions" and not "Deploy from a branch": GitHub's
-# legacy branch-deploy pipeline has failed server-side (deployments stuck
-# queued), leaving the live feed stale while the branch was current. This
-# workflow uploads the branch as an artifact and deploys it explicitly instead.
+# CI, build, and release/distribution moved to Xcode Cloud
+# (build / test / archive -> App Store Connect). This workflow is intentionally
+# commented out rather than deleted so the original definition is preserved.
 #
-# Why appcast.xml lives on gh-pages and not main: it is a build artifact kept
-# out of main's source tree. It is an accumulating feed — each release prepends
-# its item to the existing feed (full version history). release.yml
-# publishes it to gh-pages.
+# To restore: uncomment the block below and, if it was disabled on GitHub,
+# re-enable it with `gh workflow enable "Deploy appcast to Pages"`.
+# ============================================================================
+
+# # Deploys the gh-pages branch (which holds appcast.xml, the Sparkle update feed)
+# # to the live GitHub Pages site.
+# #
+# # Why Pages source is "GitHub Actions" and not "Deploy from a branch": GitHub's
+# # legacy branch-deploy pipeline has failed server-side (deployments stuck
+# # queued), leaving the live feed stale while the branch was current. This
+# # workflow uploads the branch as an artifact and deploys it explicitly instead.
+# #
+# # Why appcast.xml lives on gh-pages and not main: it is a build artifact kept
+# # out of main's source tree. It is an accumulating feed — each release prepends
+# # its item to the existing feed (full version history). release.yml
+# # publishes it to gh-pages.
+# #
+# # The release workflow dispatches this workflow explicitly after it publishes
+# # a validated appcast. A normal push to main and a release dry-run never deploy
+# # the feed.
+# name: Deploy appcast to Pages
 #
-# The release workflow dispatches this workflow explicitly after it publishes
-# a validated appcast. A normal push to main and a release dry-run never deploy
-# the feed.
-name: Deploy appcast to Pages
-
-on:
-  workflow_dispatch:
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: gh-pages
-
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        with:
-          path: .
-
-      - id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+# on:
+#   workflow_dispatch:
+#
+# permissions:
+#   contents: read
+#   pages: write
+#   id-token: write
+#
+# concurrency:
+#   group: pages
+#   cancel-in-progress: false
+#
+# jobs:
+#   deploy:
+#     runs-on: ubuntu-latest
+#     environment:
+#       name: github-pages
+#       url: ${{ steps.deployment.outputs.page_url }}
+#     steps:
+#       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#         with:
+#           ref: gh-pages
+#
+#       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+#         with:
+#           path: .
+#
+#       - id: deployment
+#         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,300 +1,311 @@
-name: Release
+# ============================================================================
+# DISABLED: Release
+#
+# CI, build, and release/distribution moved to Xcode Cloud
+# (build / test / archive -> App Store Connect). This workflow is intentionally
+# commented out rather than deleted so the original definition is preserved.
+#
+# To restore: uncomment the block below and, if it was disabled on GitHub,
+# re-enable it with `gh workflow enable "Release"`.
+# ============================================================================
 
-on:
-  workflow_dispatch:
-    inputs:
-      operation:
-        description: "Release operation"
-        type: choice
-        options: [dry-run, publish, publish-unsigned, repair-appcast]
-        default: dry-run
-      bump:
-        description: "Version bump type (ignored when resuming an untagged version)"
-        type: choice
-        options: [auto, patch, minor, major]
-        default: auto
-      tag:
-        description: "Existing vX.Y.Z tag (required only for repair-appcast)"
-        type: string
-        required: false
-
-permissions:
-  contents: read
-
-concurrency:
-  group: release
-  cancel-in-progress: false
-
-env:
-  APP_NAME: AgentUsage
-  SCHEME: AgentUsage
-
-jobs:
-  dry-run:
-    name: Dry run
-    if: inputs.operation == 'dry-run'
-    runs-on: macos-26
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout main
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: main
-          fetch-depth: 0
-
-      - name: Compute version and release notes
-        id: version
-        uses: ./.github/actions/compute-version
-        with:
-          bump: ${{ inputs.bump }}
-
-      - name: Run tests
-        if: steps.version.outputs.skip != 'true'
-        run: |
-          xcodebuild -project "${APP_NAME}.xcodeproj" \
-            -scheme "$SCHEME" \
-            -destination 'platform=macOS' \
-            -derivedDataPath build/DryRunDerivedData \
-            test \
-            CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_REQUIRED=NO
-
-      - name: Simulate version and changelog update
-        if: steps.version.outputs.skip != 'true' && steps.version.outputs.resume != 'true'
-        uses: ./.github/actions/bump-version
-        with:
-          version: ${{ steps.version.outputs.version }}
-          build-number: ${{ steps.version.outputs.build-number }}
-          last-tag: ${{ steps.version.outputs.last-tag }}
-          notes: ${{ steps.version.outputs.notes }}
-          app-name: ${{ env.APP_NAME }}
-
-      - name: Build and validate ad-hoc-signed archive
-        if: steps.version.outputs.skip != 'true'
-        run: .github/scripts/release/build-unsigned-release.sh
-
-      - name: Report dry run
-        if: steps.version.outputs.skip != 'true'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          BUILD: ${{ steps.version.outputs.build-number }}
-          BUMP: ${{ steps.version.outputs.bump }}
-          RESUME: ${{ steps.version.outputs.resume }}
-          NOTES: ${{ steps.version.outputs.notes }}
-        run: |
-          {
-            echo "## Dry run: $VERSION (build $BUILD)"
-            echo ""
-            echo "- Resolution: $BUMP"
-            echo "- Resuming committed version: $RESUME"
-            echo ""
-            echo "$NOTES"
-          } >> "$GITHUB_STEP_SUMMARY"
-          git diff -- Config/Version.xcconfig "${APP_NAME}.xcodeproj/project.pbxproj" CHANGELOG.md
-
-  publish:
-    name: Publish release
-    if: inputs.operation == 'publish' || inputs.operation == 'publish-unsigned'
-    runs-on: macos-26
-    environment: release
-    permissions:
-      actions: write
-      contents: write
-    steps:
-      - name: Checkout main
-        id: checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: main
-          fetch-depth: 0
-
-      - name: Validate release gate
-        env:
-          OPERATION: ${{ inputs.operation }}
-          SIGNED_RELEASES_ENABLED: ${{ vars.SIGNED_RELEASES_ENABLED }}
-          UNSIGNED_RELEASES_ENABLED: ${{ vars.UNSIGNED_RELEASES_ENABLED }}
-          DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_BASE64 }}
-          DEVELOPER_ID_APPLICATION_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_PASSWORD }}
-          APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
-          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
-          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-        run: .github/scripts/release/check-release-gate.sh
-
-      - name: Compute version and release notes
-        id: version
-        uses: ./.github/actions/compute-version
-        with:
-          bump: ${{ inputs.bump }}
-
-      - name: Run tests
-        if: steps.version.outputs.skip != 'true'
-        run: |
-          xcodebuild -project "${APP_NAME}.xcodeproj" \
-            -scheme "$SCHEME" \
-            -destination 'platform=macOS' \
-            -derivedDataPath build/ReleaseDerivedData \
-            test \
-            CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_REQUIRED=NO
-
-      - name: Prepare version and changelog
-        if: steps.version.outputs.skip != 'true' && steps.version.outputs.resume != 'true'
-        uses: ./.github/actions/bump-version
-        with:
-          version: ${{ steps.version.outputs.version }}
-          build-number: ${{ steps.version.outputs.build-number }}
-          last-tag: ${{ steps.version.outputs.last-tag }}
-          notes: ${{ steps.version.outputs.notes }}
-          app-name: ${{ env.APP_NAME }}
-
-      - name: Compose release notes
-        if: steps.version.outputs.skip != 'true'
-        env:
-          NOTES: ${{ steps.version.outputs.notes }}
-        run: |
-          .github/scripts/release/render-release-notes.py \
-            --markdown "$RUNNER_TEMP/release-notes.md" \
-            --html "$RUNNER_TEMP/release-notes.html" \
-            --repository "$GITHUB_REPOSITORY"
-
-      - name: Configure Developer ID signing
-        if: steps.version.outputs.skip != 'true' && inputs.operation == 'publish'
-        env:
-          DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_BASE64 }}
-          DEVELOPER_ID_APPLICATION_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_PASSWORD }}
-          APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
-          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
-        run: .github/scripts/release/configure-signing.sh
-
-      - name: Build, sign, and notarize
-        if: steps.version.outputs.skip != 'true' && inputs.operation == 'publish'
-        env:
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
-          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
-        run: .github/scripts/release/build-signed-release.sh
-
-      - name: Build and ad-hoc sign
-        if: steps.version.outputs.skip != 'true' && inputs.operation == 'publish-unsigned'
-        run: .github/scripts/release/build-unsigned-release.sh
-
-      - name: Generate and validate appcast
-        if: steps.version.outputs.skip != 'true'
-        uses: ./.github/actions/generate-appcast
-        with:
-          version: ${{ steps.version.outputs.version }}
-          build-number: ${{ steps.version.outputs.build-number }}
-          tag: ${{ steps.version.outputs.tag }}
-          notes-file: ${{ runner.temp }}/release-notes.html
-          sparkle-private-key: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-          app-name: ${{ env.APP_NAME }}
-
-      - name: Commit version and changelog
-        if: steps.version.outputs.skip != 'true'
-        uses: ./.github/actions/commit-push
-        with:
-          files: Config/Version.xcconfig ${{ env.APP_NAME }}.xcodeproj/project.pbxproj CHANGELOG.md
-          message: Bump version to ${{ steps.version.outputs.version }}
-          strategy: abort-on-moved-main
-
-      - name: Confirm tested main has not moved
-        if: steps.version.outputs.skip != 'true'
-        run: |
-          git fetch origin main
-          if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
-            echo "::error::main moved after validation; aborting before tag and release creation"
-            exit 1
-          fi
-
-      - name: Create GitHub release
-        if: steps.version.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.version.outputs.version }}
-          TAG: ${{ steps.version.outputs.tag }}
-          NOTES_FILE: ${{ runner.temp }}/release-notes.md
-        run: .github/scripts/release/create-github-release.sh
-
-      - name: Publish appcast to gh-pages
-        if: steps.version.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          TAG: ${{ steps.version.outputs.tag }}
-        run: .github/scripts/release/publish-appcast.sh
-
-      - name: Deploy appcast with Pages workflow
-        if: steps.version.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh workflow run pages.yml --ref main --repo "$GITHUB_REPOSITORY"
-
-      - name: Clean up signing material
-        if: always() && steps.checkout.outcome == 'success' && inputs.operation == 'publish'
-        run: .github/scripts/release/cleanup-signing.sh
-
-  repair-appcast:
-    name: Repair published appcast
-    if: inputs.operation == 'repair-appcast'
-    runs-on: macos-26
-    environment: release
-    permissions:
-      actions: write
-      contents: write
-    steps:
-      - name: Checkout main
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: main
-          fetch-depth: 0
-
-      - name: Validate release gate
-        env:
-          OPERATION: repair-appcast
-          SIGNED_RELEASES_ENABLED: ${{ vars.SIGNED_RELEASES_ENABLED }}
-          UNSIGNED_RELEASES_ENABLED: ${{ vars.UNSIGNED_RELEASES_ENABLED }}
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-        run: .github/scripts/release/check-release-gate.sh
-
-      - name: Download and validate release archive
-        id: repair
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ inputs.tag }}
-          SIGNED_RELEASES_ENABLED: ${{ vars.SIGNED_RELEASES_ENABLED }}
-          UNSIGNED_RELEASES_ENABLED: ${{ vars.UNSIGNED_RELEASES_ENABLED }}
-        run: .github/scripts/release/prepare-appcast-repair.sh
-
-      - name: Compose repair release notes
-        run: |
-          .github/scripts/release/render-release-notes.py \
-            --markdown "$RUNNER_TEMP/release-notes.md" \
-            --html "$RUNNER_TEMP/release-notes.html" \
-            --notes-file "${{ steps.repair.outputs.notes_path }}" \
-            --repository "$GITHUB_REPOSITORY"
-
-      - name: Regenerate and validate appcast
-        uses: ./.github/actions/generate-appcast
-        with:
-          version: ${{ steps.repair.outputs.version }}
-          build-number: ${{ steps.repair.outputs.build }}
-          tag: ${{ inputs.tag }}
-          notes-file: ${{ runner.temp }}/release-notes.html
-          sparkle-private-key: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-          app-name: ${{ env.APP_NAME }}
-          archive-path: ${{ steps.repair.outputs.archive_path }}
-
-      - name: Publish repaired appcast to gh-pages
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          TAG: ${{ inputs.tag }}
-        run: .github/scripts/release/publish-appcast.sh
-
-      - name: Deploy repaired appcast with Pages workflow
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh workflow run pages.yml --ref main --repo "$GITHUB_REPOSITORY"
+# name: Release
+#
+# on:
+#   workflow_dispatch:
+#     inputs:
+#       operation:
+#         description: "Release operation"
+#         type: choice
+#         options: [dry-run, publish, publish-unsigned, repair-appcast]
+#         default: dry-run
+#       bump:
+#         description: "Version bump type (ignored when resuming an untagged version)"
+#         type: choice
+#         options: [auto, patch, minor, major]
+#         default: auto
+#       tag:
+#         description: "Existing vX.Y.Z tag (required only for repair-appcast)"
+#         type: string
+#         required: false
+#
+# permissions:
+#   contents: read
+#
+# concurrency:
+#   group: release
+#   cancel-in-progress: false
+#
+# env:
+#   APP_NAME: AgentUsage
+#   SCHEME: AgentUsage
+#
+# jobs:
+#   dry-run:
+#     name: Dry run
+#     if: inputs.operation == 'dry-run'
+#     runs-on: macos-26
+#     permissions:
+#       contents: read
+#     steps:
+#       - name: Checkout main
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#         with:
+#           ref: main
+#           fetch-depth: 0
+#
+#       - name: Compute version and release notes
+#         id: version
+#         uses: ./.github/actions/compute-version
+#         with:
+#           bump: ${{ inputs.bump }}
+#
+#       - name: Run tests
+#         if: steps.version.outputs.skip != 'true'
+#         run: |
+#           xcodebuild -project "${APP_NAME}.xcodeproj" \
+#             -scheme "$SCHEME" \
+#             -destination 'platform=macOS' \
+#             -derivedDataPath build/DryRunDerivedData \
+#             test \
+#             CODE_SIGN_IDENTITY="-" \
+#             CODE_SIGNING_REQUIRED=NO
+#
+#       - name: Simulate version and changelog update
+#         if: steps.version.outputs.skip != 'true' && steps.version.outputs.resume != 'true'
+#         uses: ./.github/actions/bump-version
+#         with:
+#           version: ${{ steps.version.outputs.version }}
+#           build-number: ${{ steps.version.outputs.build-number }}
+#           last-tag: ${{ steps.version.outputs.last-tag }}
+#           notes: ${{ steps.version.outputs.notes }}
+#           app-name: ${{ env.APP_NAME }}
+#
+#       - name: Build and validate ad-hoc-signed archive
+#         if: steps.version.outputs.skip != 'true'
+#         run: .github/scripts/release/build-unsigned-release.sh
+#
+#       - name: Report dry run
+#         if: steps.version.outputs.skip != 'true'
+#         env:
+#           VERSION: ${{ steps.version.outputs.version }}
+#           BUILD: ${{ steps.version.outputs.build-number }}
+#           BUMP: ${{ steps.version.outputs.bump }}
+#           RESUME: ${{ steps.version.outputs.resume }}
+#           NOTES: ${{ steps.version.outputs.notes }}
+#         run: |
+#           {
+#             echo "## Dry run: $VERSION (build $BUILD)"
+#             echo ""
+#             echo "- Resolution: $BUMP"
+#             echo "- Resuming committed version: $RESUME"
+#             echo ""
+#             echo "$NOTES"
+#           } >> "$GITHUB_STEP_SUMMARY"
+#           git diff -- Config/Version.xcconfig "${APP_NAME}.xcodeproj/project.pbxproj" CHANGELOG.md
+#
+#   publish:
+#     name: Publish release
+#     if: inputs.operation == 'publish' || inputs.operation == 'publish-unsigned'
+#     runs-on: macos-26
+#     environment: release
+#     permissions:
+#       actions: write
+#       contents: write
+#     steps:
+#       - name: Checkout main
+#         id: checkout
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#         with:
+#           ref: main
+#           fetch-depth: 0
+#
+#       - name: Validate release gate
+#         env:
+#           OPERATION: ${{ inputs.operation }}
+#           SIGNED_RELEASES_ENABLED: ${{ vars.SIGNED_RELEASES_ENABLED }}
+#           UNSIGNED_RELEASES_ENABLED: ${{ vars.UNSIGNED_RELEASES_ENABLED }}
+#           DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+#           DEVELOPER_ID_APPLICATION_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_PASSWORD }}
+#           APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
+#           APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+#           APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+#           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+#           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+#         run: .github/scripts/release/check-release-gate.sh
+#
+#       - name: Compute version and release notes
+#         id: version
+#         uses: ./.github/actions/compute-version
+#         with:
+#           bump: ${{ inputs.bump }}
+#
+#       - name: Run tests
+#         if: steps.version.outputs.skip != 'true'
+#         run: |
+#           xcodebuild -project "${APP_NAME}.xcodeproj" \
+#             -scheme "$SCHEME" \
+#             -destination 'platform=macOS' \
+#             -derivedDataPath build/ReleaseDerivedData \
+#             test \
+#             CODE_SIGN_IDENTITY="-" \
+#             CODE_SIGNING_REQUIRED=NO
+#
+#       - name: Prepare version and changelog
+#         if: steps.version.outputs.skip != 'true' && steps.version.outputs.resume != 'true'
+#         uses: ./.github/actions/bump-version
+#         with:
+#           version: ${{ steps.version.outputs.version }}
+#           build-number: ${{ steps.version.outputs.build-number }}
+#           last-tag: ${{ steps.version.outputs.last-tag }}
+#           notes: ${{ steps.version.outputs.notes }}
+#           app-name: ${{ env.APP_NAME }}
+#
+#       - name: Compose release notes
+#         if: steps.version.outputs.skip != 'true'
+#         env:
+#           NOTES: ${{ steps.version.outputs.notes }}
+#         run: |
+#           .github/scripts/release/render-release-notes.py \
+#             --markdown "$RUNNER_TEMP/release-notes.md" \
+#             --html "$RUNNER_TEMP/release-notes.html" \
+#             --repository "$GITHUB_REPOSITORY"
+#
+#       - name: Configure Developer ID signing
+#         if: steps.version.outputs.skip != 'true' && inputs.operation == 'publish'
+#         env:
+#           DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+#           DEVELOPER_ID_APPLICATION_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_PASSWORD }}
+#           APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
+#           APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+#         run: .github/scripts/release/configure-signing.sh
+#
+#       - name: Build, sign, and notarize
+#         if: steps.version.outputs.skip != 'true' && inputs.operation == 'publish'
+#         env:
+#           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+#           APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+#           APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+#         run: .github/scripts/release/build-signed-release.sh
+#
+#       - name: Build and ad-hoc sign
+#         if: steps.version.outputs.skip != 'true' && inputs.operation == 'publish-unsigned'
+#         run: .github/scripts/release/build-unsigned-release.sh
+#
+#       - name: Generate and validate appcast
+#         if: steps.version.outputs.skip != 'true'
+#         uses: ./.github/actions/generate-appcast
+#         with:
+#           version: ${{ steps.version.outputs.version }}
+#           build-number: ${{ steps.version.outputs.build-number }}
+#           tag: ${{ steps.version.outputs.tag }}
+#           notes-file: ${{ runner.temp }}/release-notes.html
+#           sparkle-private-key: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+#           app-name: ${{ env.APP_NAME }}
+#
+#       - name: Commit version and changelog
+#         if: steps.version.outputs.skip != 'true'
+#         uses: ./.github/actions/commit-push
+#         with:
+#           files: Config/Version.xcconfig ${{ env.APP_NAME }}.xcodeproj/project.pbxproj CHANGELOG.md
+#           message: Bump version to ${{ steps.version.outputs.version }}
+#           strategy: abort-on-moved-main
+#
+#       - name: Confirm tested main has not moved
+#         if: steps.version.outputs.skip != 'true'
+#         run: |
+#           git fetch origin main
+#           if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+#             echo "::error::main moved after validation; aborting before tag and release creation"
+#             exit 1
+#           fi
+#
+#       - name: Create GitHub release
+#         if: steps.version.outputs.skip != 'true'
+#         env:
+#           GH_TOKEN: ${{ github.token }}
+#           VERSION: ${{ steps.version.outputs.version }}
+#           TAG: ${{ steps.version.outputs.tag }}
+#           NOTES_FILE: ${{ runner.temp }}/release-notes.md
+#         run: .github/scripts/release/create-github-release.sh
+#
+#       - name: Publish appcast to gh-pages
+#         if: steps.version.outputs.skip != 'true'
+#         env:
+#           GH_TOKEN: ${{ github.token }}
+#           REPO: ${{ github.repository }}
+#           TAG: ${{ steps.version.outputs.tag }}
+#         run: .github/scripts/release/publish-appcast.sh
+#
+#       - name: Deploy appcast with Pages workflow
+#         if: steps.version.outputs.skip != 'true'
+#         env:
+#           GH_TOKEN: ${{ github.token }}
+#         run: gh workflow run pages.yml --ref main --repo "$GITHUB_REPOSITORY"
+#
+#       - name: Clean up signing material
+#         if: always() && steps.checkout.outcome == 'success' && inputs.operation == 'publish'
+#         run: .github/scripts/release/cleanup-signing.sh
+#
+#   repair-appcast:
+#     name: Repair published appcast
+#     if: inputs.operation == 'repair-appcast'
+#     runs-on: macos-26
+#     environment: release
+#     permissions:
+#       actions: write
+#       contents: write
+#     steps:
+#       - name: Checkout main
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#         with:
+#           ref: main
+#           fetch-depth: 0
+#
+#       - name: Validate release gate
+#         env:
+#           OPERATION: repair-appcast
+#           SIGNED_RELEASES_ENABLED: ${{ vars.SIGNED_RELEASES_ENABLED }}
+#           UNSIGNED_RELEASES_ENABLED: ${{ vars.UNSIGNED_RELEASES_ENABLED }}
+#           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+#         run: .github/scripts/release/check-release-gate.sh
+#
+#       - name: Download and validate release archive
+#         id: repair
+#         env:
+#           GH_TOKEN: ${{ github.token }}
+#           TAG: ${{ inputs.tag }}
+#           SIGNED_RELEASES_ENABLED: ${{ vars.SIGNED_RELEASES_ENABLED }}
+#           UNSIGNED_RELEASES_ENABLED: ${{ vars.UNSIGNED_RELEASES_ENABLED }}
+#         run: .github/scripts/release/prepare-appcast-repair.sh
+#
+#       - name: Compose repair release notes
+#         run: |
+#           .github/scripts/release/render-release-notes.py \
+#             --markdown "$RUNNER_TEMP/release-notes.md" \
+#             --html "$RUNNER_TEMP/release-notes.html" \
+#             --notes-file "${{ steps.repair.outputs.notes_path }}" \
+#             --repository "$GITHUB_REPOSITORY"
+#
+#       - name: Regenerate and validate appcast
+#         uses: ./.github/actions/generate-appcast
+#         with:
+#           version: ${{ steps.repair.outputs.version }}
+#           build-number: ${{ steps.repair.outputs.build }}
+#           tag: ${{ inputs.tag }}
+#           notes-file: ${{ runner.temp }}/release-notes.html
+#           sparkle-private-key: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+#           app-name: ${{ env.APP_NAME }}
+#           archive-path: ${{ steps.repair.outputs.archive_path }}
+#
+#       - name: Publish repaired appcast to gh-pages
+#         env:
+#           GH_TOKEN: ${{ github.token }}
+#           REPO: ${{ github.repository }}
+#           TAG: ${{ inputs.tag }}
+#         run: .github/scripts/release/publish-appcast.sh
+#
+#       - name: Deploy repaired appcast with Pages workflow
+#         env:
+#           GH_TOKEN: ${{ github.token }}
+#         run: gh workflow run pages.yml --ref main --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## What

Comments out all three GitHub Actions workflows — `ci.yml`, `release.yml`, and `pages.yml` — rather than deleting them. Each file's original definition is preserved as comments, with a header explaining the disable and how to restore.

## Why

CI, build, and release/distribution have moved to **Xcode Cloud** (build/test/archive → App Store Connect):

- Sparkle's package dependency was already removed (`38bae98`) and the app now shows the Updates section only in App Store builds (`57ac490`), so the Sparkle **appcast** pipeline is dead.
- `release.yml` + `pages.yml` published the appcast to `gh-pages` / GitHub Pages — obsolete.
- `ci.yml` (GitHub-native PR/push build + test) is redundant with Xcode Cloud's PR checks.

A fully commented file registers no workflow, so none of the three can trigger. Commenting (vs. deleting) keeps the definitions recoverable and makes the disable **version-controlled** (unlike the earlier `gh workflow disable`, which lives only in GitHub state).

## Notes

- These three were also previously set to `disabled_manually` via `gh workflow disable`. Once this merges, the commented files de-register them regardless; the GitHub disabled state becomes moot and can optionally be cleared.
- If `CI` was a **required** status check in branch protection, update the rule so PRs aren't blocked waiting on a check that will never register.
- Left for a separate cleanup pass: orphaned Sparkle release infra (`.github/actions/*`, `.github/scripts/release/*`, `SU*` keys in `AgentUsage/Info.plist`, dead `UpdaterController.swift`, `RELEASING.md` / release skill docs).

https://claude.ai/code/session_01JUEWPAdpjPWLZov7dxxsio