### PR TITLE
Collapse local data access to a single one-time home-folder grant

### DIFF
--- a/AgentUsage/AgentUsageApp.swift
+++ b/AgentUsage/AgentUsageApp.swift
@@ -130,6 +130,13 @@ struct AgentUsageApp: App {
         } label: {
             MenuBarIconView()
                 .environment(viewModel)
+                .task {
+                    // Refresh immediately when the user grants local data access
+                    // from the first-run onboarding, without waiting for the next cycle.
+                    for await _ in NotificationCenter.default.notifications(named: .localDataAccessGranted) {
+                        _ = await viewModel.refresh(force: true)
+                    }
+                }
         }
         .menuBarExtraStyle(.window)
         #else

--- a/AgentUsage/macOS/AppDelegate.swift
+++ b/AgentUsage/macOS/AppDelegate.swift
@@ -28,15 +28,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     // MARK: - First-run local data access
 
-    /// Show the single, one-time local-data-access prompt at first launch when the
-    /// sandboxed app has no read grant yet. Marked complete once shown so it never
-    /// nags again — the grant stays available in Settings.
+    /// Show the one-time local-data-access prompt at first launch when the sandboxed
+    /// app has no Full Disk Access or saved folder grant yet. Marked complete once
+    /// shown so it never nags again — the setup remains available in Settings.
     private func presentDataAccessOnboardingIfNeeded() {
         let defaults = UserDefaults.standard
         guard !defaults.bool(forKey: Self.onboardingCompletedKey) else { return }
 
         // Already have access (including a migrated legacy grant): nothing to ask.
-        guard !SandboxFolderAccessService.shared.hasFullAccess else {
+        guard !SandboxFolderAccessService.shared.hasAnyAccess else {
             defaults.set(true, forKey: Self.onboardingCompletedKey)
             return
         }

--- a/AgentUsage/macOS/AppDelegate.swift
+++ b/AgentUsage/macOS/AppDelegate.swift
@@ -7,10 +7,14 @@
 
 #if os(macOS)
 import AppKit
+import SwiftUI
 import UserNotifications
 
 final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
     private var windowObservers: [NSObjectProtocol] = []
+    private var onboardingWindow: NSWindow?
+
+    private static let onboardingCompletedKey = "hasCompletedDataAccessOnboarding"
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         setupWindowObservers()
@@ -18,6 +22,50 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Set notification delegate to show banners even when app is in foreground
         UNUserNotificationCenter.current().delegate = self
+
+        presentDataAccessOnboardingIfNeeded()
+    }
+
+    // MARK: - First-run local data access
+
+    /// Show the single, one-time local-data-access prompt at first launch when the
+    /// sandboxed app has no read grant yet. Marked complete once shown so it never
+    /// nags again — the grant stays available in Settings.
+    private func presentDataAccessOnboardingIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: Self.onboardingCompletedKey) else { return }
+
+        // Already have access (including a migrated legacy grant): nothing to ask.
+        guard !SandboxFolderAccessService.shared.hasFullAccess else {
+            defaults.set(true, forKey: Self.onboardingCompletedKey)
+            return
+        }
+
+        // Asked at start — mark complete now so any dismissal path is one-and-done.
+        defaults.set(true, forKey: Self.onboardingCompletedKey)
+
+        let content = DataAccessOnboardingView { [weak self] in
+            self?.onboardingWindow?.close()
+            self?.onboardingWindow = nil
+            self?.updateActivationPolicy()
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 320),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = Constants.appDisplayName
+        window.titlebarAppearsTransparent = true
+        window.isReleasedWhenClosed = false
+        window.contentView = NSHostingView(rootView: content)
+        window.center()
+        onboardingWindow = window
+
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
     }
 
     // MARK: - UNUserNotificationCenterDelegate

--- a/AgentUsage/macOS/Services/SandboxFolderAccessService.swift
+++ b/AgentUsage/macOS/Services/SandboxFolderAccessService.swift
@@ -3,8 +3,8 @@
 //  AgentUsage
 //
 //  Grants the sandboxed macOS app read access to the CLI tools' log directories
-//  (`~/.claude`, `~/.codex`, `~/.local/share/opencode`) via user-selected folders
-//  and persisted security-scoped bookmarks.
+//  (`~/.claude`, `~/.codex`, `~/.local/share/opencode`) via a single, one-time
+//  user-selected home-folder grant and a persisted security-scoped bookmark.
 //
 
 #if os(macOS)
@@ -12,29 +12,37 @@ import Foundation
 import AppKit
 import AgentUsageKit
 
-/// Manages user-granted, security-scoped read access to the local log directories
-/// that the App Sandbox otherwise hides.
+/// Manages a single user-granted, security-scoped read grant covering the home
+/// directory, which the App Sandbox otherwise hides.
 ///
-/// Access model: bookmarks are persisted in the App Group defaults suite, resolved
-/// once at launch, and their security scope is **held for the process lifetime**
+/// Access model: the user grants read access to their home folder **once**. That
+/// one grant covers every provider's log directory (all are subpaths of home).
+/// The bookmark is persisted in the App Group defaults suite, resolved once at
+/// launch, and its security scope is **held for the process lifetime**
 /// (`startAccessingSecurityScopedResource` without a matching stop until deinit).
 /// This suits a continuously-refreshing menu-bar app and means the file-reading
 /// services need no per-read scope wrapping — they read the real paths from
 /// `Constants` and access is ambient once `resolveExistingGrants()` has run.
+///
+/// Legacy per-provider bookmarks from earlier builds are still resolved at launch
+/// so upgraders keep access without re-granting.
 @MainActor
 @Observable
 final class SandboxFolderAccessService {
     static let shared = SandboxFolderAccessService()
 
-    /// Providers that have a local directory a user can grant access to.
+    /// Providers whose logs are covered once home access is granted.
     /// `.openCodeGo` is remote-only, so it is not included.
     static let grantableProviders: [Provider] = [.claude, .codex, .openCode]
 
-    /// Provider ids whose bookmarks are currently resolved and access-started.
-    private(set) var grantedProviders: Set<Provider> = []
+    /// Whether the single home-folder grant is currently resolved and access-started.
+    private(set) var hasFullAccess = false
 
-    /// URLs whose security scope we are holding open, so we can release on deinit.
-    private var activeScopedURLs: [Provider: URL] = [:]
+    /// The home URL whose security scope we are holding open, if granted.
+    private var homeScopedURL: URL?
+
+    /// Legacy per-provider scoped URLs resolved from earlier builds' bookmarks.
+    private var legacyScopedURLs: [Provider: URL] = [:]
 
     private let defaults: UserDefaults
 
@@ -54,25 +62,28 @@ final class SandboxFolderAccessService {
         }
     }
 
+    /// Whether a provider's logs are readable — true when the home grant is active,
+    /// or when a legacy per-provider grant from an earlier build is still resolved.
     func hasAccess(to provider: Provider) -> Bool {
-        grantedProviders.contains(provider)
+        hasFullAccess || legacyScopedURLs[provider] != nil
     }
 
-    /// Present an open panel for the provider's directory and, on selection, persist
-    /// a security-scoped bookmark and begin holding its scope. Returns whether access
-    /// is now granted.
+    /// Present a single open panel defaulting to the user's home folder and, on
+    /// selection, persist a security-scoped bookmark and begin holding its scope.
+    /// This one grant covers every provider. Returns whether access is now granted.
     @discardableResult
-    func requestAccess(to provider: Provider) -> Bool {
-        let target = defaultDirectory(for: provider)
+    func requestFullAccess() -> Bool {
+        let target = Constants.realHomeDirectory
 
         let panel = NSOpenPanel()
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false
         panel.canCreateDirectories = false
-        panel.showsHiddenFiles = true          // .claude / .codex are hidden
+        panel.showsHiddenFiles = true          // logs live in hidden dot-directories
         panel.directoryURL = target
-        panel.message = "Grant read access to \(provider.displayName)'s local usage logs at \(target.path)."
+        panel.message = "Grant read access to your home folder so \(Constants.appDisplayName) "
+            + "can read the local usage logs for Claude, Codex, and OpenCode. This is asked only once."
         panel.prompt = "Grant Access"
 
         guard panel.runModal() == .OK, let url = panel.url else {
@@ -85,73 +96,104 @@ final class SandboxFolderAccessService {
                 includingResourceValuesForKeys: nil,
                 relativeTo: nil
             )
-            defaults.set(bookmark, forKey: bookmarkDefaultsKey(for: provider))
-            startAccess(to: provider, url: url)
-            return true
+            defaults.set(bookmark, forKey: homeBookmarkKey)
+            startHomeAccess(url: url)
+            // The home grant supersedes any legacy per-provider grants; drop them.
+            clearLegacyGrants()
+            return hasFullAccess
         } catch {
-            NSLog("SandboxFolderAccessService: failed to create bookmark for \(provider.rawValue): \(error)")
+            NSLog("SandboxFolderAccessService: failed to create home bookmark: \(error)")
             return false
         }
     }
 
-    /// Stop holding the scope and forget the stored bookmark for a provider.
-    func revokeAccess(to provider: Provider) {
-        if let url = activeScopedURLs.removeValue(forKey: provider) {
+    /// Stop holding the home scope and forget the stored bookmark (and any legacy
+    /// per-provider bookmarks).
+    func revokeAccess() {
+        if let url = homeScopedURL {
             url.stopAccessingSecurityScopedResource()
+            homeScopedURL = nil
         }
-        defaults.removeObject(forKey: bookmarkDefaultsKey(for: provider))
-        grantedProviders.remove(provider)
+        defaults.removeObject(forKey: homeBookmarkKey)
+        hasFullAccess = false
+        clearLegacyGrants()
     }
 
     // MARK: - Launch resolution
 
-    /// Resolve every persisted bookmark and begin holding its scope. Called once at
-    /// init; re-creates stale bookmarks opportunistically.
+    /// Resolve the persisted home bookmark and begin holding its scope. Called once
+    /// at init; falls back to legacy per-provider bookmarks so upgraders keep access.
     private func resolveExistingGrants() {
-        for provider in Self.grantableProviders {
-            guard let bookmark = defaults.data(forKey: bookmarkDefaultsKey(for: provider)) else {
-                continue
+        if let bookmark = defaults.data(forKey: homeBookmarkKey) {
+            resolve(bookmark: bookmark, key: homeBookmarkKey) { [weak self] url in
+                self?.startHomeAccess(url: url)
             }
-            var isStale = false
-            do {
-                let url = try URL(
-                    resolvingBookmarkData: bookmark,
-                    options: [.withSecurityScope],
-                    relativeTo: nil,
-                    bookmarkDataIsStale: &isStale
-                )
-                startAccess(to: provider, url: url)
+        }
 
-                if isStale {
-                    // Refresh the bookmark while we hold the scope, so it keeps resolving.
-                    if let refreshed = try? url.bookmarkData(
-                        options: .withSecurityScope,
-                        includingResourceValuesForKeys: nil,
-                        relativeTo: nil
-                    ) {
-                        defaults.set(refreshed, forKey: bookmarkDefaultsKey(for: provider))
-                    }
+        // Legacy fallback: earlier builds stored one bookmark per provider. Keep
+        // resolving them until the user grants the unified home access.
+        guard !hasFullAccess else { return }
+        for provider in Self.grantableProviders {
+            let key = legacyBookmarkKey(for: provider)
+            guard let bookmark = defaults.data(forKey: key) else { continue }
+            resolve(bookmark: bookmark, key: key) { [weak self] url in
+                if url.startAccessingSecurityScopedResource() {
+                    self?.legacyScopedURLs[provider] = url
                 }
-            } catch {
-                NSLog("SandboxFolderAccessService: failed to resolve bookmark for \(provider.rawValue): \(error)")
             }
         }
     }
 
-    private func startAccess(to provider: Provider, url: URL) {
-        // Release any prior scope for this provider before replacing it.
-        if let previous = activeScopedURLs.removeValue(forKey: provider) {
+    /// Resolve a security-scoped bookmark, refreshing it in place if stale, and hand
+    /// the resulting URL to `onResolved`.
+    private func resolve(bookmark: Data, key: String, onResolved: (URL) -> Void) {
+        var isStale = false
+        do {
+            let url = try URL(
+                resolvingBookmarkData: bookmark,
+                options: [.withSecurityScope],
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            )
+            onResolved(url)
+
+            if isStale, let refreshed = try? url.bookmarkData(
+                options: .withSecurityScope,
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            ) {
+                defaults.set(refreshed, forKey: key)
+            }
+        } catch {
+            NSLog("SandboxFolderAccessService: failed to resolve bookmark \(key): \(error)")
+        }
+    }
+
+    private func startHomeAccess(url: URL) {
+        // Release any prior scope before replacing it.
+        if let previous = homeScopedURL {
             previous.stopAccessingSecurityScopedResource()
+            homeScopedURL = nil
         }
         if url.startAccessingSecurityScopedResource() {
-            activeScopedURLs[provider] = url
-            grantedProviders.insert(provider)
+            homeScopedURL = url
+            hasFullAccess = true
         } else {
-            NSLog("SandboxFolderAccessService: startAccessingSecurityScopedResource failed for \(provider.rawValue)")
+            NSLog("SandboxFolderAccessService: startAccessingSecurityScopedResource failed for home")
         }
     }
 
-    private func bookmarkDefaultsKey(for provider: Provider) -> String {
+    private func clearLegacyGrants() {
+        for (provider, url) in legacyScopedURLs {
+            url.stopAccessingSecurityScopedResource()
+            defaults.removeObject(forKey: legacyBookmarkKey(for: provider))
+        }
+        legacyScopedURLs.removeAll()
+    }
+
+    private let homeBookmarkKey = "sandboxFolderBookmark.home"
+
+    private func legacyBookmarkKey(for provider: Provider) -> String {
         "sandboxFolderBookmark.\(provider.rawValue)"
     }
 

--- a/AgentUsage/macOS/Services/SandboxFolderAccessService.swift
+++ b/AgentUsage/macOS/Services/SandboxFolderAccessService.swift
@@ -2,9 +2,9 @@
 //  SandboxFolderAccessService.swift
 //  AgentUsage
 //
-//  Grants the sandboxed macOS app read access to the CLI tools' log directories
-//  (`~/.claude`, `~/.codex`, `~/.local/share/opencode`) via a single, one-time
-//  user-selected home-folder grant and a persisted security-scoped bookmark.
+//  Tracks whether the sandboxed macOS app can read the CLI tools' log directories
+//  (`~/.claude`, `~/.codex`, `~/.local/share/opencode`) through Full Disk Access
+//  or previously saved security-scoped bookmarks.
 //
 
 #if os(macOS)
@@ -12,48 +12,50 @@ import Foundation
 import AppKit
 import AgentUsageKit
 
-/// Manages a single user-granted, security-scoped read grant covering the home
-/// directory, which the App Sandbox otherwise hides.
+/// Tracks local log-directory readability for the sandboxed macOS app.
 ///
-/// Access model: the user grants read access to their home folder **once**. That
-/// one grant covers every provider's log directory (all are subpaths of home).
-/// The bookmark is persisted in the App Group defaults suite, resolved once at
-/// launch, and its security scope is **held for the process lifetime**
-/// (`startAccessingSecurityScopedResource` without a matching stop until deinit).
-/// This suits a continuously-refreshing menu-bar app and means the file-reading
-/// services need no per-read scope wrapping — they read the real paths from
-/// `Constants` and access is ambient once `resolveExistingGrants()` has run.
+/// Preferred access model: the user grants Full Disk Access in System Settings.
+/// The app cannot grant that permission programmatically, so `requestFullAccess()`
+/// opens Privacy & Security and `refreshAccessStatus()` re-probes afterwards.
 ///
-/// Legacy per-provider bookmarks from earlier builds are still resolved at launch
-/// so upgraders keep access without re-granting.
+/// Legacy per-provider and home-folder security-scoped bookmarks from earlier builds
+/// are still resolved at launch so upgraders keep access without re-granting.
 @MainActor
 @Observable
 final class SandboxFolderAccessService {
     static let shared = SandboxFolderAccessService()
 
-    /// Providers whose logs are covered once home access is granted.
+    /// Providers whose logs require local disk access.
     /// `.openCodeGo` is remote-only, so it is not included.
     static let grantableProviders: [Provider] = [.claude, .codex, .openCode]
 
-    /// Whether the single home-folder grant is currently resolved and access-started.
+    /// Whether the app appears to have broad access to the real home directory.
     private(set) var hasFullAccess = false
 
-    /// The home URL whose security scope we are holding open, if granted.
+    /// Whether any broad or legacy provider-specific access is currently available.
+    var hasAnyAccess: Bool {
+        hasFullAccess || !legacyScopedURLs.isEmpty
+    }
+
+    /// The home URL whose security scope we are holding open, if a previous build saved one.
     private var homeScopedURL: URL?
 
     /// Legacy per-provider scoped URLs resolved from earlier builds' bookmarks.
     private var legacyScopedURLs: [Provider: URL] = [:]
 
     private let defaults: UserDefaults
+    private let fileManager: FileManager
 
-    private init(defaults: UserDefaults? = nil) {
+    private init(defaults: UserDefaults? = nil, fileManager: FileManager = .default) {
         self.defaults = defaults ?? UserDefaults(suiteName: Constants.appGroupIdentifier) ?? .standard
+        self.fileManager = fileManager
         resolveExistingGrants()
+        refreshAccessStatus()
     }
 
     // MARK: - Public API
 
-    /// The real directory a grant covers for a provider (e.g. real `~/.claude`).
+    /// The real directory used by a provider (e.g. real `~/.claude`).
     func defaultDirectory(for provider: Provider) -> URL {
         switch provider {
         case .claude: Constants.claudeHomeDirectory
@@ -62,54 +64,29 @@ final class SandboxFolderAccessService {
         }
     }
 
-    /// Whether a provider's logs are readable — true when the home grant is active,
-    /// or when a legacy per-provider grant from an earlier build is still resolved.
+    /// Whether a provider's logs are readable through Full Disk Access or a legacy bookmark.
     func hasAccess(to provider: Provider) -> Bool {
-        hasFullAccess || legacyScopedURLs[provider] != nil
+        hasFullAccess || legacyScopedURLs[provider] != nil || canReadDirectory(defaultDirectory(for: provider))
     }
 
-    /// Present a single open panel defaulting to the user's home folder and, on
-    /// selection, persist a security-scoped bookmark and begin holding its scope.
-    /// This one grant covers every provider. Returns whether access is now granted.
+    /// Open System Settings to Full Disk Access. macOS requires the user to complete
+    /// the grant there; this method cannot grant access by itself.
     @discardableResult
     func requestFullAccess() -> Bool {
-        let target = Constants.realHomeDirectory
-
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = true
-        panel.canChooseFiles = false
-        panel.allowsMultipleSelection = false
-        panel.canCreateDirectories = false
-        panel.showsHiddenFiles = true          // logs live in hidden dot-directories
-        panel.directoryURL = target
-        panel.message = "Grant read access to your home folder so \(Constants.appDisplayName) "
-            + "can read the local usage logs for Claude, Codex, and OpenCode. This is asked only once."
-        panel.prompt = "Grant Access"
-
-        guard panel.runModal() == .OK, let url = panel.url else {
-            return false
-        }
-
-        do {
-            let bookmark = try url.bookmarkData(
-                options: .withSecurityScope,
-                includingResourceValuesForKeys: nil,
-                relativeTo: nil
-            )
-            defaults.set(bookmark, forKey: homeBookmarkKey)
-            startHomeAccess(url: url)
-            // The home grant supersedes any legacy per-provider grants; drop them.
-            clearLegacyGrants()
-            return hasFullAccess
-        } catch {
-            NSLog("SandboxFolderAccessService: failed to create home bookmark: \(error)")
-            return false
-        }
+        openFullDiskAccessSettings()
+        refreshAccessStatus()
+        return hasFullAccess
     }
 
-    /// Stop holding the home scope and forget the stored bookmark (and any legacy
-    /// per-provider bookmarks).
-    func revokeAccess() {
+    /// Re-check whether Full Disk Access or saved bookmarks currently make the real
+    /// home/log directories readable. Call this after the user returns from Settings.
+    func refreshAccessStatus() {
+        hasFullAccess = homeScopedURL != nil || canReadDirectory(Constants.realHomeDirectory)
+    }
+
+    /// Stop holding and forget any saved security-scoped bookmarks from previous
+    /// builds. Full Disk Access itself can only be revoked in System Settings.
+    func clearSavedFolderGrants() {
         if let url = homeScopedURL {
             url.stopAccessingSecurityScopedResource()
             homeScopedURL = nil
@@ -117,12 +94,18 @@ final class SandboxFolderAccessService {
         defaults.removeObject(forKey: homeBookmarkKey)
         hasFullAccess = false
         clearLegacyGrants()
+        refreshAccessStatus()
+    }
+
+    /// Backwards-compatible name for existing callers; this only clears saved
+    /// bookmarks and cannot revoke Full Disk Access.
+    func revokeAccess() {
+        clearSavedFolderGrants()
     }
 
     // MARK: - Launch resolution
 
-    /// Resolve the persisted home bookmark and begin holding its scope. Called once
-    /// at init; falls back to legacy per-provider bookmarks so upgraders keep access.
+    /// Resolve persisted bookmarks from earlier builds and begin holding their scopes.
     private func resolveExistingGrants() {
         if let bookmark = defaults.data(forKey: homeBookmarkKey) {
             resolve(bookmark: bookmark, key: homeBookmarkKey) { [weak self] url in
@@ -131,8 +114,8 @@ final class SandboxFolderAccessService {
         }
 
         // Legacy fallback: earlier builds stored one bookmark per provider. Keep
-        // resolving them until the user grants the unified home access.
-        guard !hasFullAccess else { return }
+        // resolving them until the user grants broader access.
+        guard homeScopedURL == nil else { return }
         for provider in Self.grantableProviders {
             let key = legacyBookmarkKey(for: provider)
             guard let bookmark = defaults.data(forKey: key) else { continue }
@@ -170,7 +153,6 @@ final class SandboxFolderAccessService {
     }
 
     private func startHomeAccess(url: URL) {
-        // Release any prior scope before replacing it.
         if let previous = homeScopedURL {
             previous.stopAccessingSecurityScopedResource()
             homeScopedURL = nil
@@ -180,6 +162,35 @@ final class SandboxFolderAccessService {
             hasFullAccess = true
         } else {
             NSLog("SandboxFolderAccessService: startAccessingSecurityScopedResource failed for home")
+        }
+    }
+
+    @discardableResult
+    private func openFullDiskAccessSettings() -> Bool {
+        let candidates = [
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
+            "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_AllFiles"
+        ]
+
+        for candidate in candidates {
+            guard let url = URL(string: candidate) else { continue }
+            if NSWorkspace.shared.open(url) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func canReadDirectory(_ url: URL) -> Bool {
+        do {
+            _ = try fileManager.contentsOfDirectory(
+                at: url,
+                includingPropertiesForKeys: nil,
+                options: [.skipsPackageDescendants]
+            )
+            return true
+        } catch {
+            return false
         }
     }
 
@@ -198,7 +209,7 @@ final class SandboxFolderAccessService {
     }
 
     // No deinit cleanup: this is a process-lifetime singleton, and the sandbox
-    // releases held security scopes automatically on termination. `revokeAccess`
+    // releases held security scopes automatically on termination. `clearSavedFolderGrants`
     // handles the only case where a scope is released during the app's lifetime.
 }
 #endif

--- a/AgentUsage/macOS/Views/DataAccessOnboardingView.swift
+++ b/AgentUsage/macOS/Views/DataAccessOnboardingView.swift
@@ -1,0 +1,77 @@
+//
+//  DataAccessOnboardingView.swift
+//  AgentUsage
+//
+//  First-run sheet asking, once, for the single home-folder grant that lets the
+//  sandboxed app read the CLI tools' local usage logs.
+//
+
+#if os(macOS)
+import SwiftUI
+import AgentUsageKit
+
+extension Notification.Name {
+    /// Posted after the user grants local data access, so live views can refresh.
+    static let localDataAccessGranted = Notification.Name("localDataAccessGranted")
+}
+
+struct DataAccessOnboardingView: View {
+    /// Invoked to dismiss the hosting window, whether the user grants or skips.
+    let onClose: () -> Void
+
+    @State private var folderAccess = SandboxFolderAccessService.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            HStack(spacing: 14) {
+                Image(systemName: "folder.badge.person.crop")
+                    .font(.largeTitle)
+                    .foregroundStyle(Constants.brandPrimary)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Allow Local Data Access")
+                        .font(.title2.weight(.semibold))
+                    Text("Asked only once")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Text(
+                "\(Constants.appDisplayName) runs sandboxed, so it needs your permission to read "
+                    + "your home folder, where each tool keeps its local usage logs. One grant "
+                    + "covers token usage, cost, and blog sync for all supported tools."
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(SandboxFolderAccessService.grantableProviders) { provider in
+                    Label(provider.displayName, systemImage: provider.iconName)
+                        .font(.callout)
+                }
+            }
+            .padding(.leading, 2)
+
+            Spacer(minLength: 0)
+
+            HStack {
+                Button("Not Now") {
+                    onClose()
+                }
+                Spacer()
+                Button("Grant Access…") {
+                    if folderAccess.requestFullAccess() {
+                        NotificationCenter.default.post(name: .localDataAccessGranted, object: nil)
+                    }
+                    onClose()
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(28)
+        .frame(width: 440, height: 320)
+    }
+}
+#endif

--- a/AgentUsage/macOS/Views/DataAccessOnboardingView.swift
+++ b/AgentUsage/macOS/Views/DataAccessOnboardingView.swift
@@ -2,8 +2,8 @@
 //  DataAccessOnboardingView.swift
 //  AgentUsage
 //
-//  First-run sheet asking, once, for the single home-folder grant that lets the
-//  sandboxed app read the CLI tools' local usage logs.
+//  First-run sheet directing users to Full Disk Access so the sandboxed app can
+//  read local CLI usage logs without a folder picker.
 //
 
 #if os(macOS)
@@ -16,7 +16,7 @@ extension Notification.Name {
 }
 
 struct DataAccessOnboardingView: View {
-    /// Invoked to dismiss the hosting window, whether the user grants or skips.
+    /// Invoked to dismiss the hosting window, whether the user opens Settings or skips.
     let onClose: () -> Void
 
     @State private var folderAccess = SandboxFolderAccessService.shared
@@ -24,22 +24,22 @@ struct DataAccessOnboardingView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             HStack(spacing: 14) {
-                Image(systemName: "folder.badge.person.crop")
+                Image(systemName: "lock.shield")
                     .font(.largeTitle)
                     .foregroundStyle(Constants.brandPrimary)
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Allow Local Data Access")
                         .font(.title2.weight(.semibold))
-                    Text("Asked only once")
+                    Text("Requires Full Disk Access")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
             }
 
             Text(
-                "\(Constants.appDisplayName) runs sandboxed, so it needs your permission to read "
-                    + "your home folder, where each tool keeps its local usage logs. One grant "
-                    + "covers token usage, cost, and blog sync for all supported tools."
+                "\(Constants.appDisplayName) runs sandboxed, so macOS blocks direct reads from "
+                    + "the hidden folders where Claude, Codex, and OpenCode keep local usage logs. "
+                    + "Enable Full Disk Access in Privacy & Security, then return here and refresh."
             )
             .font(.callout)
             .foregroundStyle(.secondary)
@@ -60,10 +60,8 @@ struct DataAccessOnboardingView: View {
                     onClose()
                 }
                 Spacer()
-                Button("Grant Access…") {
-                    if folderAccess.requestFullAccess() {
-                        NotificationCenter.default.post(name: .localDataAccessGranted, object: nil)
-                    }
+                Button("Open Privacy Settings") {
+                    folderAccess.requestFullAccess()
                     onClose()
                 }
                 .buttonStyle(.borderedProminent)

--- a/AgentUsage/macOS/Views/SettingsTabView.swift
+++ b/AgentUsage/macOS/Views/SettingsTabView.swift
@@ -514,41 +514,50 @@ struct SettingsTabView: View {
     }
 
     private var localDataAccessCard: some View {
-        settingsCard(title: "Local Data Access", systemImage: "folder.badge.person.crop") {
+        settingsCard(title: "Local Data Access", systemImage: "lock.shield") {
             VStack(alignment: .leading, spacing: 12) {
                 Text(
-                    "\(Constants.appDisplayName) runs sandboxed, so it needs your permission "
-                        + "once to read your home folder, where each tool keeps its local usage "
-                        + "logs. This unlocks token usage, cost, and blog sync for Claude, Codex, "
-                        + "and OpenCode."
+                    "\(Constants.appDisplayName) runs sandboxed, so macOS blocks direct reads "
+                        + "from the hidden folders where Claude, Codex, and OpenCode keep local "
+                        + "usage logs. Enable Full Disk Access in Privacy & Security, then check again."
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-                HStack {
+                HStack(spacing: 10) {
                     if folderAccess.hasFullAccess {
-                        Label("Access granted", systemImage: "checkmark.circle.fill")
+                        Label("Full Disk Access enabled", systemImage: "checkmark.circle.fill")
                             .font(.caption.weight(.semibold))
                             .foregroundStyle(.green)
-                        Spacer()
-                        Button("Revoke") {
-                            folderAccess.revokeAccess()
-                        }
+                    } else if folderAccess.hasAnyAccess {
+                        Label("Saved folder access available", systemImage: "checkmark.circle.fill")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.green)
                     } else {
-                        Spacer()
-                        Button("Grant Access…") {
-                            if folderAccess.requestFullAccess() {
-                                Task { _ = await viewModel.refresh(force: true) }
-                            }
-                        }
-                        .buttonStyle(.borderedProminent)
+                        Label("Access needed", systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.orange)
                     }
+
+                    Spacer()
+
+                    Button("Check Again") {
+                        folderAccess.refreshAccessStatus()
+                        if folderAccess.hasAnyAccess {
+                            Task { _ = await viewModel.refresh(force: true) }
+                        }
+                    }
+
+                    Button("Open Privacy Settings") {
+                        folderAccess.requestFullAccess()
+                    }
+                    .buttonStyle(.borderedProminent)
                 }
 
                 Divider()
 
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("Covers")
+                    Text("Reads")
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(.secondary)
                     ForEach(SandboxFolderAccessService.grantableProviders) { provider in

--- a/AgentUsage/macOS/Views/SettingsTabView.swift
+++ b/AgentUsage/macOS/Views/SettingsTabView.swift
@@ -517,41 +517,47 @@ struct SettingsTabView: View {
         settingsCard(title: "Local Data Access", systemImage: "folder.badge.person.crop") {
             VStack(alignment: .leading, spacing: 12) {
                 Text(
-                    "\(Constants.appDisplayName) runs sandboxed, so it needs your permission to "
-                        + "read each tool's local usage logs. Grant access to see token usage, cost, "
-                        + "and blog sync for Codex and OpenCode alongside Claude."
+                    "\(Constants.appDisplayName) runs sandboxed, so it needs your permission "
+                        + "once to read your home folder, where each tool keeps its local usage "
+                        + "logs. This unlocks token usage, cost, and blog sync for Claude, Codex, "
+                        + "and OpenCode."
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-                ForEach(SandboxFolderAccessService.grantableProviders) { provider in
-                    if provider != SandboxFolderAccessService.grantableProviders.first {
-                        Divider()
+                HStack {
+                    if folderAccess.hasFullAccess {
+                        Label("Access granted", systemImage: "checkmark.circle.fill")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.green)
+                        Spacer()
+                        Button("Revoke") {
+                            folderAccess.revokeAccess()
+                        }
+                    } else {
+                        Spacer()
+                        Button("Grant Access…") {
+                            if folderAccess.requestFullAccess() {
+                                Task { _ = await viewModel.refresh(force: true) }
+                            }
+                        }
+                        .buttonStyle(.borderedProminent)
                     }
-                    let granted = folderAccess.hasAccess(to: provider)
-                    HStack {
-                        VStack(alignment: .leading, spacing: 4) {
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Covers")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    ForEach(SandboxFolderAccessService.grantableProviders) { provider in
+                        HStack(spacing: 6) {
                             Label(provider.displayName, systemImage: provider.iconName)
-                                .font(.body)
+                                .font(.caption)
                             Text(folderAccess.defaultDirectory(for: provider).path)
                                 .font(.caption.monospaced())
                                 .foregroundStyle(.tertiary)
-                        }
-                        Spacer()
-                        if granted {
-                            Label("Granted", systemImage: "checkmark.circle.fill")
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(.green)
-                            Button("Revoke") {
-                                folderAccess.revokeAccess(to: provider)
-                            }
-                        } else {
-                            Button("Grant Access…") {
-                                if folderAccess.requestAccess(to: provider) {
-                                    Task { _ = await viewModel.refresh(force: true) }
-                                }
-                            }
-                            .buttonStyle(.borderedProminent)
                         }
                     }
                 }


### PR DESCRIPTION
- Simplify folder access model to request a single home-folder grant instead of separate folder grants
- Add DataAccessOnboardingView for guiding users through initial setup
- Update SandboxFolderAccessService to handle unified home-folder access with persistent bookmarks
- Surface CloudKit usage-sync errors with concrete CKError codes for better debugging