### PR TITLE
Fix usage correctness bugs across providers and windows

### DIFF
--- a/AgentUsage/AgentUsageApp.swift
+++ b/AgentUsage/AgentUsageApp.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 #if os(macOS)
+import OSLog
 import SwiftData
 #endif
 
@@ -67,10 +68,21 @@ struct AgentUsageApp: App {
             )
         }
 
+        // A corrupt store or a failed migration must not be an unrecoverable launch
+        // crash: the persisted token/history data is a local cache rebuilt from the
+        // CLI logs, so fall back to an in-memory store and let the app run degraded.
         do {
             modelContainer = try ModelContainer(for: schema, configurations: [modelConfiguration])
         } catch {
-            fatalError("Could not initialize ModelContainer: \(error)")
+            Logger.viewModel.error("Persistent ModelContainer unavailable, falling back to in-memory: \(error.localizedDescription)")
+            do {
+                modelContainer = try ModelContainer(
+                    for: schema,
+                    configurations: [ModelConfiguration(schema: schema, isStoredInMemoryOnly: true, cloudKitDatabase: .none)]
+                )
+            } catch {
+                fatalError("Could not initialize an in-memory ModelContainer: \(error)")
+            }
         }
 
         // Use DependencyContainer for view model creation

--- a/AgentUsage/Services/ClaudeAPIService.swift
+++ b/AgentUsage/Services/ClaudeAPIService.swift
@@ -61,6 +61,28 @@ actor ClaudeAPIService: APIServiceProtocol {
         }
     }
 
+    /// `ISO8601DateFormatter` treats `.withFractionalSeconds` as *required*, so a
+    /// formatter configured for it rejects `2026-07-25T10:00:00Z`. The usage endpoint
+    /// normally sends fractional seconds, but a response without them would otherwise
+    /// fall back to `Date()` and render every window as already reset.
+    private static let fractionalTimestampFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let wholeSecondTimestampFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    static func parseTimestamp(_ value: String?) -> Date? {
+        guard let value, !value.isEmpty else { return nil }
+        return fractionalTimestampFormatter.date(from: value)
+            ?? wholeSecondTimestampFormatter.date(from: value)
+    }
+
     func fetchUsage(token: String) async throws -> UsageSnapshot {
         var lastError: APIError?
 
@@ -143,17 +165,17 @@ actor ClaudeAPIService: APIServiceProtocol {
         }
     }
 
-    /// Calculate retry delay with exponential backoff
+    /// Calculate retry delay with exponential backoff, capped at `Constants.maxRetryDelay`.
     private func calculateRetryDelay(attempt: Int, error: APIError) -> TimeInterval {
         // For rate limiting, use Retry-After header if available
         if case .rateLimited(let retryAfter) = error, let seconds = retryAfter {
-            return seconds
+            return min(seconds, Constants.maxRetryDelay)
         }
 
         // Exponential backoff: 1s, 2s, 4s, etc.
         let baseDelay = Constants.initialRetryDelay
         let multiplier = pow(Constants.retryBackoffMultiplier, Double(attempt))
-        return baseDelay * multiplier
+        return min(baseDelay * multiplier, Constants.maxRetryDelay)
     }
 
     private func parseUsageResponse(_ data: Data) throws -> UsageSnapshot {
@@ -257,13 +279,10 @@ actor ClaudeAPIService: APIServiceProtocol {
             throw APIError.noUsageData
         }
 
-        let dateFormatter = ISO8601DateFormatter()
-        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
         let session = response.fiveHour.map {
             UsageWindow(
                 utilization: $0.utilization,
-                resetsAt: dateFormatter.date(from: $0.resetsAt) ?? Date(),
+                resetsAt: Self.parseTimestamp($0.resetsAt) ?? Date(),
                 windowType: .session
             )
         } ?? UsageWindow(utilization: 0, resetsAt: Date(), windowType: .session)
@@ -272,7 +291,7 @@ actor ClaudeAPIService: APIServiceProtocol {
         let opus = response.sevenDay.map {
             UsageWindow(
                 utilization: $0.utilization,
-                resetsAt: dateFormatter.date(from: $0.resetsAt) ?? Date(),
+                resetsAt: Self.parseTimestamp($0.resetsAt) ?? Date(),
                 windowType: .opus
             )
         } ?? UsageWindow(utilization: 0, resetsAt: Date(), windowType: .opus)
@@ -281,7 +300,7 @@ actor ClaudeAPIService: APIServiceProtocol {
         let sonnet = response.sevenDaySonnet.map {
             UsageWindow(
                 utilization: $0.utilization,
-                resetsAt: dateFormatter.date(from: $0.resetsAt) ?? Date(),
+                resetsAt: Self.parseTimestamp($0.resetsAt) ?? Date(),
                 windowType: .sonnet
             )
         }
@@ -290,7 +309,7 @@ actor ClaudeAPIService: APIServiceProtocol {
         let design = response.sevenDayOmelette.map {
             UsageWindow(
                 utilization: $0.utilization,
-                resetsAt: dateFormatter.date(from: $0.resetsAt) ?? Date(),
+                resetsAt: Self.parseTimestamp($0.resetsAt) ?? Date(),
                 windowType: .design
             )
         }
@@ -303,7 +322,7 @@ actor ClaudeAPIService: APIServiceProtocol {
             .map {
                 UsageWindow(
                     utilization: $0.percent ?? 0,
-                    resetsAt: dateFormatter.date(from: $0.resetsAt ?? "") ?? Date(),
+                    resetsAt: Self.parseTimestamp($0.resetsAt) ?? Date(),
                     windowType: .fable
                 )
             }

--- a/AgentUsage/Services/NotificationService.swift
+++ b/AgentUsage/Services/NotificationService.swift
@@ -61,8 +61,15 @@ actor NotificationService: NotificationServiceProtocol {
     private let notificationCenter: any UserNotificationCenterClient
     private nonisolated let settingsProvider: @Sendable () -> NotificationSettings
 
+    /// Identifies one window's reset period. Keeping `resetsAt` as a field rather than
+    /// baking it into a string lets eviction order by recency instead of by name.
+    private struct WindowPeriodKey: Hashable {
+        let name: String
+        let resetsAt: TimeInterval
+    }
+
     // Track notified thresholds per window type and reset time to avoid duplicates
-    private var notifiedThresholds: [String: Set<Int>] = [:]
+    private var notifiedThresholds: [WindowPeriodKey: Set<Int>] = [:]
 
     // Track whether we've already notified about extra usage activation
     private var notifiedExtraUsage: Bool = false
@@ -204,13 +211,13 @@ actor NotificationService: NotificationServiceProtocol {
         let oldPercent = oldUsage?.percentUsed ?? 0
 
         // Create unique key for this window's reset period (using second precision)
-        let windowKey = "\(name)-\(dateToSeconds(newUsage.resetsAt))"
+        let windowKey = WindowPeriodKey(name: name, resetsAt: dateToSeconds(newUsage.resetsAt))
 
         // Check if reset occurred (new reset time means new window)
         // Compare at second precision to avoid false positives from API timestamp variations
         if let oldUsage, dateToSeconds(oldUsage.resetsAt) != dateToSeconds(newUsage.resetsAt) {
             // Reset period changed, clear notified thresholds for old key
-            let oldKey = "\(name)-\(dateToSeconds(oldUsage.resetsAt))"
+            let oldKey = WindowPeriodKey(name: name, resetsAt: dateToSeconds(oldUsage.resetsAt))
             notifiedThresholds.removeValue(forKey: oldKey)
 
             // Enhanced guards for reset notification:
@@ -254,10 +261,13 @@ actor NotificationService: NotificationServiceProtocol {
             }
         }
 
-        // Clean up old window keys (keep only last 10)
+        // Clean up old window keys (keep the 10 most recent reset periods). Evicting by
+        // reset time rather than by key ordering keeps every live window's dedupe state.
         if notifiedThresholds.count > 10 {
-            let sortedKeys = notifiedThresholds.keys.sorted()
-            for key in sortedKeys.prefix(notifiedThresholds.count - 10) {
+            let staleKeys = notifiedThresholds.keys
+                .sorted { $0.resetsAt < $1.resetsAt }
+                .prefix(notifiedThresholds.count - 10)
+            for key in staleKeys {
                 notifiedThresholds.removeValue(forKey: key)
             }
         }
@@ -334,7 +344,7 @@ actor NotificationService: NotificationServiceProtocol {
         }
 
         if threshold == 100 {
-            content.body = "You've reached your \(windowDescription) limit. Resets in \(usage.timeUntilReset)."
+            content.body = "You've reached your \(windowDescription) limit. \(usage.resetDescription())."
         } else {
             content.body = "You've used \(threshold)% of your \(windowDescription) limit."
         }

--- a/AgentUsage/Shared/Views/UsageCardView.swift
+++ b/AgentUsage/Shared/Views/UsageCardView.swift
@@ -39,7 +39,7 @@ struct UsageCardView: View {
                             .font(.caption)
                             .foregroundStyle(Constants.extraUsageAccent)
                     }
-                    Text("Resets in \(usage.timeUntilReset(from: now))")
+                    Text(usage.resetDescription(from: now))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -55,7 +55,7 @@ struct UsageCardView: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityValue(accessibilityValue)
-        .accessibilityHint("Resets \(usage.timeUntilReset(from: now))")
+        .accessibilityHint(usage.resetDescription(from: now))
     }
 
     private var progressRing: some View {

--- a/AgentUsage/Utilities/Constants.swift
+++ b/AgentUsage/Utilities/Constants.swift
@@ -66,6 +66,12 @@ enum Constants {
     static let initialRetryDelay: TimeInterval = 1.0
     static let retryBackoffMultiplier: Double = 2.0
 
+    /// Upper bound on any single in-loop retry sleep. `Retry-After` can be minutes or
+    /// hours; sleeping that long inside the API actor would serialize every later
+    /// request behind it. Longer backoff is handled by `rateLimitedUntil` in the view
+    /// model, which suppresses auto-refresh without holding the actor.
+    static let maxRetryDelay: TimeInterval = 30
+
     /// Default cooldown after a rate-limit (HTTP 429) response with no `Retry-After`
     /// header. Auto-refresh is suppressed for this long so we stop hammering the
     /// endpoint that just throttled us.

--- a/AgentUsage/ViewModels/UsageViewModel.swift
+++ b/AgentUsage/ViewModels/UsageViewModel.swift
@@ -305,9 +305,10 @@ final class UsageViewModel {
     /// returned HTTP 429. Cleared on the next successful fetch.
     private var rateLimitedUntil: Date?
 
-    /// Overall status computed from the worst status across all usage windows
+    /// Overall status computed from the worst status across every provider's windows,
+    /// not Claude's alone — a single app-wide indicator must reflect Codex too.
     var overallStatus: UsageStatus {
-        UsageCalculations.overallStatus(from: snapshot)
+        UsageCalculations.overallStatus(from: snapshot, providerSnapshots: providerUsage.values)
     }
 
     /// A clear, user-facing summary of the app's connection to Claude's usage API,

--- a/AgentUsage/Views/MenuBarView.swift
+++ b/AgentUsage/Views/MenuBarView.swift
@@ -54,18 +54,18 @@ struct MenuBarView: View {
 
             Spacer()
 
-            railAction("arrow.clockwise", help: "Refresh (⌘R)") {
+            railAction("arrow.clockwise", help: "Refresh (⌘R)", key: "r") {
                 let tapped = Date()
                 if let last = lastRefreshTap, tapped.timeIntervalSince(last) < uiThrottle { return }
                 lastRefreshTap = tapped
                 Task { await viewModel.refresh(force: true) }
             }
-            railAction("gear", help: "Settings (⌘,)") {
+            railAction("gear", help: "Settings (⌘,)", key: ",") {
                 selectedTab = .settings
                 openWindow(id: Constants.mainWindowID)
                 NSApp.activate(ignoringOtherApps: true)
             }
-            railAction("power", help: "Quit (⌘Q)") {
+            railAction("power", help: "Quit (⌘Q)", key: "q") {
                 NSApplication.shared.terminate(nil)
             }
         }
@@ -100,7 +100,12 @@ struct MenuBarView: View {
         .buttonStyle(.plain)
     }
 
-    private func railAction(_ systemImage: String, help: String, action: @escaping () -> Void) -> some View {
+    private func railAction(
+        _ systemImage: String,
+        help: String,
+        key: KeyEquivalent,
+        action: @escaping () -> Void
+    ) -> some View {
         Button(action: action) {
             Image(systemName: systemImage)
                 .font(.system(size: 14))
@@ -109,6 +114,9 @@ struct MenuBarView: View {
         }
         .buttonStyle(.plain)
         .help(help)
+        // The popover is its own key window, so the app's main-menu shortcuts do not
+        // reach it. Bind them here to match what each tooltip advertises.
+        .keyboardShortcut(key, modifiers: .command)
     }
 
     // MARK: - Content

--- a/AgentUsage/Views/UsageRowView.swift
+++ b/AgentUsage/Views/UsageRowView.swift
@@ -27,7 +27,7 @@ struct UsageRowView: View {
                         .frame(width: 7, height: 7)
                 }
                 Spacer()
-                Text("Resets in \(usage.timeUntilReset(from: now))")
+                Text(usage.resetDescription(from: now))
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
@@ -79,7 +79,7 @@ struct UsageRowView: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityValue(accessibilityValue)
-        .accessibilityHint("Resets \(usage.timeUntilReset(from: now))")
+        .accessibilityHint(usage.resetDescription(from: now))
     }
 
     // MARK: - Accessibility Helpers

--- a/AgentUsage/macOS/Views/DashboardTabView.swift
+++ b/AgentUsage/macOS/Views/DashboardTabView.swift
@@ -31,7 +31,9 @@ struct DashboardTabView: View {
 
                 providerSections
 
-                if viewModel.snapshot != nil {
+                // Gated on token state, not on the Claude API: this section is built from
+                // local JSONL logs, so an API outage or a reset window must not hide it.
+                if hasTokenUsageContent {
                     dashboardSection(
                         title: "Token Usage & Cost",
                         subtitle: "Local Claude token activity and estimated spend.",
@@ -336,6 +338,14 @@ struct DashboardTabView: View {
     }
 
     // MARK: - Token Usage Section with States
+
+    /// Whether `tokenUsageSectionWithStates` has anything to render, so the section
+    /// header is not shown above empty content.
+    private var hasTokenUsageContent: Bool {
+        viewModel.tokenSnapshot != nil
+            || viewModel.isLoadingTokenUsage
+            || viewModel.tokenUsageError != nil
+    }
 
     @ViewBuilder
     private var tokenUsageSectionWithStates: some View {

--- a/AgentUsageKit/Sources/AgentUsageKit/Models/UsageData.swift
+++ b/AgentUsageKit/Sources/AgentUsageKit/Models/UsageData.swift
@@ -248,6 +248,15 @@ public struct UsageWindow: Sendable, Codable {
         }
     }
 
+    /// Full user-facing reset phrase.
+    ///
+    /// `timeUntilReset` returns the bare word "now" for an elapsed window, which reads
+    /// as "Resets in now" when callers prefix it. Use this wherever the countdown is
+    /// presented as a sentence.
+    public func resetDescription(from now: Date = Date()) -> String {
+        resetsAt <= now ? "Resets now" : "Resets in \(timeUntilReset(from: now))"
+    }
+
     /// Calculate usage status based on absolute usage and consumption rate
     public var status: UsageStatus {
         let timeRemaining = resetsAt.timeIntervalSinceNow

--- a/AgentUsageKit/Sources/AgentUsageKit/Utilities/UsageCalculations.swift
+++ b/AgentUsageKit/Sources/AgentUsageKit/Utilities/UsageCalculations.swift
@@ -28,4 +28,22 @@ public enum UsageCalculations {
         guard let snapshot else { return .onTrack }
         return overallStatus(from: [snapshot.session, snapshot.opus, snapshot.sonnet, snapshot.design, snapshot.fable])
     }
+
+    /// Compute the overall worst status across Claude and every other monitored provider.
+    ///
+    /// Surfaces that present a single "how bad is it" indicator for the whole app must
+    /// use this: reading Claude alone reports on-track while another provider is at 98%.
+    public static func overallStatus(
+        from snapshot: UsageSnapshot?,
+        providerSnapshots: some Sequence<ProviderUsageSnapshot>
+    ) -> UsageStatus {
+        var windows: [UsageWindow?] = []
+        if let snapshot {
+            windows.append(contentsOf: [snapshot.session, snapshot.opus, snapshot.sonnet, snapshot.design, snapshot.fable])
+        }
+        for providerSnapshot in providerSnapshots where providerSnapshot.provider != .claude {
+            windows.append(contentsOf: providerSnapshot.windows.map { $0 })
+        }
+        return overallStatus(from: windows)
+    }
 }

--- a/AgentUsageWidgets/Views/LargeWidgetView.swift
+++ b/AgentUsageWidgets/Views/LargeWidgetView.swift
@@ -63,7 +63,7 @@ struct LargeWidgetView: View {
                         .font(.caption2)
                         .foregroundStyle(trendColor(for: usage.trend))
                 }
-                Text("Resets in \(usage.timeUntilReset)")
+                Text(usage.resetDescription())
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -89,7 +89,7 @@ struct LargeWidgetView: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(title) usage")
         .accessibilityValue("\(usage.percentUsed) percent used, \(usage.status.label), \(usage.trend.accessibilityLabel)")
-        .accessibilityHint("Resets in \(usage.timeUntilReset)")
+        .accessibilityHint(usage.resetDescription())
     }
 
     private func trendColor(for trend: UsageWindow.Trend) -> Color {

--- a/AgentUsageWidgets/Views/LockScreenWidgetView.swift
+++ b/AgentUsageWidgets/Views/LockScreenWidgetView.swift
@@ -67,13 +67,13 @@ struct LockScreenWidgetView: View {
             }
             .gaugeStyle(.accessoryLinear)
 
-            Text("Resets in \(usage.timeUntilReset)")
+            Text(usage.resetDescription())
                 .font(.caption2)
                 .foregroundStyle(.secondary)
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(entry.metric.displayName) usage")
-        .accessibilityValue("\(usage.percentUsed) percent, resets in \(usage.timeUntilReset)")
+        .accessibilityValue("\(usage.percentUsed) percent, \(usage.resetDescription().lowercased())")
     }
 
     // MARK: - Inline (Single line text)


### PR DESCRIPTION
- Parse Claude reset timestamps with and without fractional seconds; `.withFractionalSeconds` is required by `ISO8601DateFormatter`, so a whole-second timestamp fell back to `Date()`, expired every window and wiped the snapshot to "No usage data"
- Compute overall status across all providers instead of Claude alone, so a Codex window near its limit no longer reads as on-track
- Gate the macOS Token Usage & Cost section on token state rather than the Claude snapshot, since it is built from local JSONL logs and should survive an API outage
- Evict notification dedupe state by reset time instead of key ordering, which previously purged windows by name and dropped live periods
- Cap in-loop retry sleeps at 30s so a long `Retry-After` no longer holds the API actor; `rateLimitedUntil` still handles longer backoff
- Add `UsageWindow.resetDescription` so an elapsed window reads "Resets now" rather than "Resets in now"
- Bind the menu bar popover's advertised ⌘R/⌘,/⌘Q shortcuts, which were tooltips with nothing behind them
- Fall back to an in-memory store when the persistent `ModelContainer` cannot open, instead of `fatalError` at launch

`AgentUsageKit/Services/ClaudeUsageService.swift` has the same timestamp bug but no references anywhere; left for a separate decision on removing it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tartinerlabs/codesmith/AgentUsage/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787515244&installation_model_id=427837&pr_number=86&repository=tartinerlabs%2FAgentUsage&return_to=https%3A%2F%2Fgithub.com%2Ftartinerlabs%2FAgentUsage%2Fpull%2F86&signature=1b58add1f0240007e1d0079117003b594fbbb5b6727fca09ff1aaa9c382cd08b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->