### PR TITLE
Read Xcode Coding Assistant logs and fix @State shadowing

### DIFF
--- a/AgentUsage/Services/BlogUsage/BlogUsageSourceIndexer.swift
+++ b/AgentUsage/Services/BlogUsage/BlogUsageSourceIndexer.swift
@@ -152,11 +152,14 @@ actor BlogUsageSourceIndexer: BlogUsageIndexing {
     // MARK: - JSONL discovery and incremental parsing
 
     private func discoverJSONLFiles() throws -> [DiscoveredFile] {
+        let xcodeRoot = Constants.xcodeCodingAssistantPath
         let roots: [(BlogUsageIndexedSource, URL)] = [
             (.claude, parser.homeDirectory.appendingPathComponent(".claude/projects")),
             (.claude, parser.homeDirectory.appendingPathComponent(".config/claude/projects")),
+            (.claude, parser.homeDirectory.appendingPathComponent("\(xcodeRoot)/ClaudeAgentConfig/projects")),
             (.codex, parser.homeDirectory.appendingPathComponent(".codex/sessions")),
-            (.codex, parser.homeDirectory.appendingPathComponent(".codex/archived_sessions"))
+            (.codex, parser.homeDirectory.appendingPathComponent(".codex/archived_sessions")),
+            (.codex, parser.homeDirectory.appendingPathComponent("\(xcodeRoot)/codex/sessions"))
         ]
         let keys: Set<URLResourceKey> = [
             .isRegularFileKey,
@@ -176,6 +179,7 @@ actor BlogUsageSourceIndexer: BlogUsageIndexing {
                 continue
             }
 
+            let countBefore = result.count
             for case let url as URL in enumerator where url.pathExtension == "jsonl" {
                 guard let values = try? url.resourceValues(forKeys: keys),
                       values.isRegularFile == true else {
@@ -188,6 +192,11 @@ actor BlogUsageSourceIndexer: BlogUsageIndexing {
                     fileSize: Int64(values.fileSize ?? 0),
                     modificationDate: values.contentModificationDate ?? .distantPast
                 ))
+            }
+            // A root that exists but yields nothing is usually a sandbox read that was
+            // denied, not an empty directory — it looks identical to "no usage" otherwise.
+            if result.count == countBefore {
+                Logger.blogUsage.notice("Log root produced no JSONL files: \(root.path, privacy: .public)")
             }
         }
         return result.sorted { $0.url.path < $1.url.path }

--- a/AgentUsage/Services/BlogUsage/BlogUsageSyncService.swift
+++ b/AgentUsage/Services/BlogUsage/BlogUsageSyncService.swift
@@ -287,7 +287,8 @@ nonisolated struct BlogUsageSourceParser {
     nonisolated func parseClaudeEvents() throws -> [BlogUsageEvent] {
         let roots = [
             homeDirectory.appendingPathComponent(".claude/projects"),
-            homeDirectory.appendingPathComponent(".config/claude/projects")
+            homeDirectory.appendingPathComponent(".config/claude/projects"),
+            homeDirectory.appendingPathComponent("\(Constants.xcodeCodingAssistantPath)/ClaudeAgentConfig/projects")
         ]
         let files = try roots.flatMap { try jsonlFiles(in: $0) }
         var seen = Set<String>()
@@ -307,7 +308,8 @@ nonisolated struct BlogUsageSourceParser {
     nonisolated func parseCodexEvents() throws -> [BlogUsageEvent] {
         let roots = [
             homeDirectory.appendingPathComponent(".codex/sessions"),
-            homeDirectory.appendingPathComponent(".codex/archived_sessions")
+            homeDirectory.appendingPathComponent(".codex/archived_sessions"),
+            homeDirectory.appendingPathComponent("\(Constants.xcodeCodingAssistantPath)/codex/sessions")
         ]
         let files = try roots.flatMap { try jsonlFiles(in: $0) }
         var events: [BlogUsageEvent] = []

--- a/AgentUsage/Shared/Utilities/Logger.swift
+++ b/AgentUsage/Shared/Utilities/Logger.swift
@@ -35,6 +35,9 @@ extension Logger {
     /// Usage history service logging
     static let history = Logger(subsystem: subsystem, category: "History")
 
+    /// Blog usage sync logging (log-root discovery, incremental indexing, upload)
+    static let blogUsage = Logger(subsystem: subsystem, category: "BlogUsage")
+
     // MARK: - UI Loggers
 
     /// ViewModel logging (state changes, refresh operations)

--- a/AgentUsage/Shared/Views/ContinuityOnboardingMap.swift
+++ b/AgentUsage/Shared/Views/ContinuityOnboardingMap.swift
@@ -6,14 +6,17 @@
 import SwiftUI
 
 struct ContinuityOnboardingMap: View {
-    enum State: Equatable {
+    /// Deliberately not named `State`: `@State` is a macro as of SDK 27, so its
+    /// attribute name resolves through normal lookup and a nested `State` shadows
+    /// `SwiftUI.State`, leaving `@State` properties unwrapped.
+    enum ConnectionState: Equatable {
         case idle
         case connecting
         case connected
         case waiting
     }
 
-    let state: State
+    let state: ConnectionState
     let highlightsMobileDevice: Bool
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion

--- a/AgentUsage/Utilities/Constants.swift
+++ b/AgentUsage/Utilities/Constants.swift
@@ -145,11 +145,18 @@ enum Constants {
         realHomeDirectory.appendingPathComponent(".local/share/opencode")
     }
 
+    /// Xcode's Coding Assistant bundles its own Claude Code and Codex agent homes,
+    /// separate from the CLI ones. Sessions run from Xcode write only here, in the
+    /// same on-disk formats. Note this lives outside every per-provider grant root
+    /// above, so it is readable only under Full Disk Access or a home-folder grant.
+    nonisolated static let xcodeCodingAssistantPath = "Library/Developer/Xcode/CodingAssistant"
+
     nonisolated static var claudeProjectsDirectories: [URL] {
         let home = realHomeDirectory
         return [
             home.appendingPathComponent(".claude/projects"),
-            home.appendingPathComponent(".config/claude/projects")
+            home.appendingPathComponent(".config/claude/projects"),
+            home.appendingPathComponent("\(xcodeCodingAssistantPath)/ClaudeAgentConfig/projects")
         ]
     }
 
@@ -157,7 +164,9 @@ enum Constants {
     nonisolated static var codexSessionsDirectories: [URL] {
         let home = realHomeDirectory
         return [
-            home.appendingPathComponent(".codex/sessions")
+            home.appendingPathComponent(".codex/sessions"),
+            home.appendingPathComponent(".codex/archived_sessions"),
+            home.appendingPathComponent("\(xcodeCodingAssistantPath)/codex/sessions")
         ]
     }
 

--- a/AgentUsage/iOS/Views/ContinuityOnboardingView.swift
+++ b/AgentUsage/iOS/Views/ContinuityOnboardingView.swift
@@ -12,7 +12,7 @@ struct ContinuityOnboardingView: View {
 
     @Environment(UsageViewModel.self) private var viewModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var connectionState: ContinuityOnboardingMap.State = .idle
+    @State private var connectionState: ContinuityOnboardingMap.ConnectionState = .idle
     @State private var statusMessage: String?
 
     var body: some View {

--- a/AgentUsage/macOS/Views/DataAccessOnboardingView.swift
+++ b/AgentUsage/macOS/Views/DataAccessOnboardingView.swift
@@ -14,7 +14,7 @@ struct DataAccessOnboardingView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var folderAccess = SandboxFolderAccessService.shared
-    @State private var connectionState: ContinuityOnboardingMap.State = .idle
+    @State private var connectionState: ContinuityOnboardingMap.ConnectionState = .idle
     @State private var accessMessage: AccessMessage?
 
     init(


### PR DESCRIPTION
- Add Xcode's Coding Assistant roots (`ClaudeAgentConfig/projects`, `codex/sessions`) to the Claude and Codex log sources, so sessions run from Xcode are counted by both the in-app display and the blog sync — they write to their own agent homes and were invisible to every parser
- Add the missing `~/.codex/archived_sessions` root to the in-app Codex source; the blog-sync indexer already had it, so the app was under-reporting Codex
- Log a configured root that exists but yields no files — these roots sit outside every per-provider sandbox grant, so a denied read is otherwise indistinguishable from having no usage
- Rename `ContinuityOnboardingMap.State` to `ConnectionState`: `@State` is a macro as of SDK 27, so its attribute name resolves through normal lookup and a nested `State` shadowed `SwiftUI.State`, leaving `@State` properties unwrapped (four Xcode Cloud errors on both platforms)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tartinerlabs/codesmith/AgentUsage/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787602107&installation_model_id=427837&pr_number=87&repository=tartinerlabs%2FAgentUsage&return_to=https%3A%2F%2Fgithub.com%2Ftartinerlabs%2FAgentUsage%2Fpull%2F87&signature=3795db40bd54e22539d77d0764d453d71eac32904f9986857a18c4298e4e1009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->