### PR TITLE
Fix Claude session migration and unavailable token usage handling

### DIFF
--- a/AgentUsage/Models/EffortUsage.swift
+++ b/AgentUsage/Models/EffortUsage.swift
@@ -55,12 +55,11 @@ nonisolated enum EffortUsageAggregator {
     ) -> [Provider: [EffortPeriodSummary]] {
         var sessions: [SessionKey: SessionAccumulator] = [:]
 
-        for (index, sample) in samples.enumerated() where !sample.isSubagentSession {
-            // A parser should always supply a stable session id. Keep malformed or
-            // migrated records independent rather than merging every empty id.
-            let sessionID = sample.sessionID.isEmpty
-                ? "legacy-\(index)-\(sample.timestamp.timeIntervalSince1970)"
-                : sample.sessionID
+        for sample in samples where !sample.isSubagentSession {
+            // Request rows without a stable session identity cannot contribute to
+            // session-level coverage without inflating one request into one session.
+            let sessionID = sample.sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !sessionID.isEmpty else { continue }
             let key = SessionKey(provider: sample.provider, sessionID: sessionID)
             var accumulator = sessions[key] ?? SessionAccumulator(
                 latestTimestamp: sample.timestamp,

--- a/AgentUsage/Models/TokenLogEntry.swift
+++ b/AgentUsage/Models/TokenLogEntry.swift
@@ -23,14 +23,17 @@ final class TokenLogEntry {
     /// Model name (e.g., "claude-opus-4-5-20250514")
     var modelName: String
 
-    /// Claude session identifier. Empty for rows imported before session metadata was captured.
-    var sessionID: String = ""
+    /// Claude session identifier. Nil or empty for legacy rows imported before
+    /// session metadata was captured. This stays optional so rows written by an
+    /// older app binary after a lightweight migration remain materializable.
+    var sessionID: String? = nil
 
     /// Normalized effort-level value. Optional for logs and migrated rows that do not expose it.
     var effortLevelRaw: String? = nil
 
-    /// True for entries imported from Claude subagent session files.
-    var isSubagentSession: Bool = false
+    /// True for entries imported from Claude subagent session files. Nil is the
+    /// migration-safe legacy representation and is treated as false by readers.
+    var isSubagentSession: Bool? = nil
 
     /// Token counts
     var inputTokens: Int
@@ -60,9 +63,9 @@ final class TokenLogEntry {
         cacheReadTokens: Int,
         timestamp: Date,
         costUSD: Double,
-        sessionID: String = "",
+        sessionID: String? = nil,
         effortLevelRaw: String? = nil,
-        isSubagentSession: Bool = false,
+        isSubagentSession: Bool? = nil,
         cacheCreation1hTokens: Int = 0,
         isFastMode: Bool = false
     ) {

--- a/AgentUsage/Models/TokenUsage.swift
+++ b/AgentUsage/Models/TokenUsage.swift
@@ -691,6 +691,10 @@ nonisolated struct ProviderDetail: Sendable {
     let dailyCosts: [Double]
     /// Session effort distributions for each supported period.
     let effortSummaries: [EffortPeriodSummary]
+    /// False when this value only carries cached effort metadata. Keeping that
+    /// state distinct prevents an unavailable token refresh from looking like
+    /// a successful refresh with genuine $0 / 0-token totals.
+    let hasTokenUsage: Bool
 
     init(
         today: TokenUsageSummary,
@@ -698,7 +702,8 @@ nonisolated struct ProviderDetail: Sendable {
         last30Days: TokenUsageSummary,
         byModel: [String: TokenCount],
         dailyCosts: [Double],
-        effortSummaries: [EffortPeriodSummary] = []
+        effortSummaries: [EffortPeriodSummary] = [],
+        hasTokenUsage: Bool = true
     ) {
         self.today = today
         self.yesterday = yesterday
@@ -706,6 +711,7 @@ nonisolated struct ProviderDetail: Sendable {
         self.byModel = byModel
         self.dailyCosts = dailyCosts
         self.effortSummaries = effortSummaries
+        self.hasTokenUsage = hasTokenUsage
     }
 
     func effortSummary(for period: EffortPeriod) -> EffortPeriodSummary? {

--- a/AgentUsage/Services/CodexLogSource.swift
+++ b/AgentUsage/Services/CodexLogSource.swift
@@ -77,7 +77,7 @@ actor CodexLogSource: UsageLogSource {
     }
 
     func fetchEntries(since: Date) async throws -> [ProviderUsageEntry] {
-        let files = rolloutFiles(modifiedAfter: since)
+        let files = try rolloutFiles(modifiedAfter: since)
         let currentURLs = Set(files.map(\.url))
         var nextDiagnostics = CodexLogSourceDiagnostics(discoveredFileCount: files.count)
         var entries: [ProviderUsageEntry] = []
@@ -134,21 +134,24 @@ actor CodexLogSource: UsageLogSource {
 
     // MARK: - File discovery
 
-    private func rolloutFiles(modifiedAfter cutoff: Date) -> [RolloutFile] {
+    private func rolloutFiles(modifiedAfter cutoff: Date) throws -> [RolloutFile] {
         let resourceKeys: Set<URLResourceKey> = [
             .isRegularFileKey,
             .contentModificationDateKey,
             .fileSizeKey,
         ]
         var result: [RolloutFile] = []
+        var foundReadableDirectory = false
 
         for directory in directories {
             guard fileManager.fileExists(atPath: directory.path),
+                  fileManager.isReadableFile(atPath: directory.path),
                   let enumerator = fileManager.enumerator(
                     at: directory,
                     includingPropertiesForKeys: Array(resourceKeys),
                     options: [.skipsHiddenFiles]
                   ) else { continue }
+            foundReadableDirectory = true
 
             for case let url as URL in enumerator {
                 guard url.pathExtension == "jsonl",
@@ -170,6 +173,9 @@ actor CodexLogSource: UsageLogSource {
             }
         }
 
+        guard foundReadableDirectory else {
+            throw UsageLogSourceError.unavailable
+        }
         return result
     }
 

--- a/AgentUsage/Services/OpenCodeLogSource.swift
+++ b/AgentUsage/Services/OpenCodeLogSource.swift
@@ -29,8 +29,11 @@ actor OpenCodeLogSource: UsageLogSource {
     }
 
     func fetchEntries(since: Date) async throws -> [ProviderUsageEntry] {
-        guard let dbURL = candidatePaths.first(where: { fileManager.fileExists(atPath: $0.path) }) else {
-            return []
+        guard let dbURL = candidatePaths.first(where: {
+            fileManager.fileExists(atPath: $0.path)
+                && fileManager.isReadableFile(atPath: $0.path)
+        }) else {
+            throw UsageLogSourceError.unavailable
         }
         return try query(dbURL: dbURL, since: since)
     }
@@ -45,7 +48,7 @@ actor OpenCodeLogSource: UsageLogSource {
             let msg = db.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown"
             if let db { sqlite3_close(db) }
             Logger.tokenUsage.warning("OpenCode DB open failed: \(msg)")
-            return []
+            throw UsageLogSourceError.unavailable
         }
         defer { sqlite3_close(db) }
         sqlite3_busy_timeout(db, 2000)
@@ -61,7 +64,7 @@ actor OpenCodeLogSource: UsageLogSource {
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             Logger.tokenUsage.warning("OpenCode query prepare failed: \(String(cString: sqlite3_errmsg(db)))")
-            return []
+            throw UsageLogSourceError.unavailable
         }
         defer { sqlite3_finalize(stmt) }
         sqlite3_bind_int64(stmt, 1, sinceMillis)

--- a/AgentUsage/Services/TokenUsageRepository.swift
+++ b/AgentUsage/Services/TokenUsageRepository.swift
@@ -82,13 +82,19 @@ actor TokenUsageQuerier {
         let descriptor = FetchDescriptor<TokenLogEntry>(
             predicate: #Predicate { $0.timestamp >= startDate }
         )
-        return try modelContext.fetch(descriptor).map { entry in
-            EffortUsageSample(
+        return try modelContext.fetch(descriptor).compactMap { entry in
+            guard let sessionID = entry.sessionID?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                !sessionID.isEmpty
+            else {
+                return nil
+            }
+            return EffortUsageSample(
                 provider: .claude,
-                sessionID: entry.sessionID.isEmpty ? entry.id : entry.sessionID,
+                sessionID: sessionID,
                 effortLevel: entry.effortLevel,
                 timestamp: entry.timestamp,
-                isSubagentSession: entry.isSubagentSession
+                isSubagentSession: entry.isSubagentSession ?? false
             )
         }
     }

--- a/AgentUsage/Services/TokenUsageService.swift
+++ b/AgentUsage/Services/TokenUsageService.swift
@@ -71,6 +71,12 @@ actor TokenUsageService: TokenUsageServiceProtocol {
         var entriesByProvider: [Provider: [ProviderUsageEntry]] = [:]
         for source in extraSources {
             guard let entries = try? await source.fetchEntries(since: since) else { continue }
+            // An empty result is still a successful read. Preserve the source
+            // provider so callers can distinguish genuine zero usage from an
+            // unavailable local source.
+            if entries.isEmpty, entriesByProvider[source.provider] == nil {
+                entriesByProvider[source.provider] = []
+            }
             for entry in entries {
                 entriesByProvider[entry.provider, default: []].append(entry)
             }

--- a/AgentUsage/Shared/Protocols/UsageLogSource.swift
+++ b/AgentUsage/Shared/Protocols/UsageLogSource.swift
@@ -8,6 +8,10 @@
 import Foundation
 import AgentUsageKit
 
+nonisolated enum UsageLogSourceError: Error {
+    case unavailable
+}
+
 /// A single usage record from a provider's local logs, normalized for aggregation.
 nonisolated struct ProviderUsageEntry: Sendable {
     let provider: Provider

--- a/AgentUsage/ViewModels/UsageViewModel.swift
+++ b/AgentUsage/ViewModels/UsageViewModel.swift
@@ -534,7 +534,8 @@ final class UsageViewModel {
                 last30Days: TokenUsageSummary(tokens: .zero, costUSD: 0, period: .last30Days),
                 byModel: [:],
                 dailyCosts: [],
-                effortSummaries: providerSnapshot.effortSummaries
+                effortSummaries: providerSnapshot.effortSummaries,
+                hasTokenUsage: false
             )
         }
         #endif

--- a/AgentUsage/ViewModels/UsageViewModel.swift
+++ b/AgentUsage/ViewModels/UsageViewModel.swift
@@ -526,18 +526,10 @@ final class UsageViewModel {
         planType = cached.planType
         providerUsage = providerUsageDictionary(from: cached.providerSnapshots)
         #if os(macOS)
-        let zeroToday = TokenUsageSummary(tokens: .zero, costUSD: 0, period: .today)
-        for providerSnapshot in cached.providerSnapshots where !providerSnapshot.effortSummaries.isEmpty {
-            providerDetails[providerSnapshot.provider] = ProviderDetail(
-                today: zeroToday,
-                yesterday: zeroToday,
-                last30Days: TokenUsageSummary(tokens: .zero, costUSD: 0, period: .last30Days),
-                byModel: [:],
-                dailyCosts: [],
-                effortSummaries: providerSnapshot.effortSummaries,
-                hasTokenUsage: false
-            )
-        }
+        providerDetails = addingUnavailableLocalUsageDetails(
+            to: [:],
+            from: providerUsage.values
+        )
         #endif
         isUsingCachedData = true
         Logger.viewModel.debug("Loaded cached snapshot from \(self.timeSinceLastUpdate ?? "unknown time")")
@@ -570,6 +562,46 @@ final class UsageViewModel {
             .filter { !Self.disabledProviders.contains($0.provider) }
             .sorted { $0.provider.rawValue < $1.provider.rawValue }
     }
+
+    #if os(macOS)
+    private func addingUnavailableLocalUsageDetails(
+        to details: [Provider: ProviderDetail],
+        from snapshots: some Sequence<ProviderUsageSnapshot>
+    ) -> [Provider: ProviderDetail] {
+        var resolved = details
+        for providerSnapshot in snapshots {
+            let provider = providerSnapshot.provider
+            guard resolved[provider] == nil,
+                  provider.supports(.tokenCost) || !providerSnapshot.effortSummaries.isEmpty
+            else {
+                continue
+            }
+
+            let previousEffort = providerDetails[provider]?.effortSummaries ?? []
+            resolved[provider] = Self.unavailableLocalUsageDetail(
+                effortSummaries: previousEffort.isEmpty
+                    ? providerSnapshot.effortSummaries
+                    : previousEffort
+            )
+        }
+        return resolved
+    }
+
+    private static func unavailableLocalUsageDetail(
+        effortSummaries: [EffortPeriodSummary]
+    ) -> ProviderDetail {
+        let zeroToday = TokenUsageSummary(tokens: .zero, costUSD: 0, period: .today)
+        return ProviderDetail(
+            today: zeroToday,
+            yesterday: zeroToday,
+            last30Days: TokenUsageSummary(tokens: .zero, costUSD: 0, period: .last30Days),
+            byModel: [:],
+            dailyCosts: [],
+            effortSummaries: effortSummaries,
+            hasTokenUsage: false
+        )
+    }
+    #endif
 
     // MARK: - Notifications
 
@@ -1118,7 +1150,11 @@ extension UsageViewModel {
             }
         }
 
-        providerDetails = await tokenUsageCoordinator.providerDetails(using: tokenSnapshot)
+        let refreshedDetails = await tokenUsageCoordinator.providerDetails(using: tokenSnapshot)
+        providerDetails = addingUnavailableLocalUsageDetails(
+            to: refreshedDetails,
+            from: providerUsage.values
+        )
     }
 
     #endif

--- a/AgentUsage/Views/MenuBarView.swift
+++ b/AgentUsage/Views/MenuBarView.swift
@@ -226,7 +226,7 @@ struct MenuBarView: View {
     // MARK: - Per-provider data
 
     private func costLines(for provider: Provider) -> [ProviderCostLine] {
-        guard let detail = viewModel.providerDetails[provider] else { return [] }
+        guard let detail = viewModel.providerDetails[provider], detail.hasTokenUsage else { return [] }
         return [
             ProviderCostLine(label: "Today", cost: detail.today.formattedCost, tokens: detail.today.formattedTokens),
             ProviderCostLine(label: "30 Days", cost: detail.last30Days.formattedCost, tokens: detail.last30Days.formattedTokens)

--- a/AgentUsage/Views/ProviderDetailView.swift
+++ b/AgentUsage/Views/ProviderDetailView.swift
@@ -54,14 +54,20 @@ struct ProviderDetailView: View {
             }
 
             if let detail {
-                costSection(detail)
-                if detail.dailyCosts.contains(where: { $0 > 0 }) {
-                    trendSection(detail)
+                if detail.hasTokenUsage {
+                    costSection(detail)
+                    if detail.dailyCosts.contains(where: { $0 > 0 }) {
+                        trendSection(detail)
+                    }
+                } else if provider.supports(.tokenCost) {
+                    Text("Local token usage is unavailable.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
                 if let effortSummary = detail.effortSummaries.first(where: { $0.period == effortPeriod }) {
                     effortSection(effortSummary)
                 }
-                if !detail.modelShares.isEmpty {
+                if detail.hasTokenUsage, !detail.modelShares.isEmpty {
                     modelsSection(detail)
                 }
             }

--- a/AgentUsage/macOS/Services/TokenUsageCoordinator.swift
+++ b/AgentUsage/macOS/Services/TokenUsageCoordinator.swift
@@ -30,7 +30,7 @@ final class TokenUsageCoordinator: TokenUsageCoordinating {
     static let lastZeroCostRecalcDateKey = "lastZeroCostRecalcDate"
     static let effortMetadataImportedVersionKey = "effortMetadataImportedVersion"
     static let costModelVersion = 3
-    static let effortMetadataVersion = 1
+    static let effortMetadataVersion = 2
     static let effortHistoryRetentionMonths = 13
 
     private let tokenService: (any TokenUsageServiceProtocol)?
@@ -149,7 +149,8 @@ final class TokenUsageCoordinator: TokenUsageCoordinating {
                     ?? TokenUsageSummary(tokens: .zero, costUSD: 0, period: .last30Days),
                 byModel: existing?.byModel ?? [:],
                 dailyCosts: existing?.dailyCosts ?? [],
-                effortSummaries: summaries
+                effortSummaries: summaries,
+                hasTokenUsage: existing?.hasTokenUsage ?? false
             )
         }
 

--- a/AgentUsageTests/CodexLogSourceTests.swift
+++ b/AgentUsageTests/CodexLogSourceTests.swift
@@ -128,6 +128,47 @@ struct CodexLogSourceTests {
         #expect(EffortUsageAggregator.summaries(from: samples).isEmpty)
     }
 
+    @Test @MainActor func successfulEmptyThirtyDayReadRemainsAvailableAlongsideOlderEffort() async throws {
+        let directory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("rollout-older-effort.jsonl")
+        let now = Date()
+        let olderTimestamp = now.addingTimeInterval(-60 * 24 * 60 * 60)
+        let content = [
+            Self.turnContext(model: "gpt-5.6-codex", effort: "high"),
+            Self.tokenCount(timestamp: olderTimestamp, input: 15),
+        ].joined(separator: "\n")
+        try Self.write(content, to: file)
+        try Self.setModificationDate(olderTimestamp, for: file)
+
+        let service = TokenUsageService(extraSources: [CodexLogSource(directories: [directory])])
+        let coordinator = TokenUsageCoordinator(
+            tokenService: service,
+            defaults: TestUserDefaults().defaults,
+            now: { now }
+        )
+
+        let details = await coordinator.providerDetails(using: nil)
+        let detail = try #require(details[.codex])
+        let effort = try #require(detail.effortSummary(for: .last90Days))
+
+        #expect(detail.hasTokenUsage)
+        #expect(detail.last30Days.tokens.totalTokens == 0)
+        #expect(effort.sessionCount(for: .high) == 1)
+    }
+
+    @Test func unavailableSourceDoesNotSynthesizeZeroTokenDetail() async {
+        let missingDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexLogSourceTests-missing-\(UUID().uuidString)")
+        let service = TokenUsageService(
+            extraSources: [CodexLogSource(directories: [missingDirectory])]
+        )
+
+        let details = await service.fetchExtraProviderDetails(since: .distantPast)
+
+        #expect(details[.codex] == nil)
+    }
+
     @Test func usesModificationDateWhenTokenTimestampIsMissing() async throws {
         let directory = try Self.temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/AgentUsageTests/EffortUsageAggregatorTests.swift
+++ b/AgentUsageTests/EffortUsageAggregatorTests.swift
@@ -58,6 +58,27 @@ struct EffortUsageAggregatorTests {
         #expect(summary.levels == [EffortLevelCount(level: .medium, sessionCount: 1)])
     }
 
+    @Test func ignoresSamplesWithoutStableSessionIdentity() throws {
+        let samples = [
+            sample(provider: .claude, session: "", level: .high, age: 100),
+            sample(provider: .claude, session: "  \n", level: .medium, age: 90),
+            sample(provider: .claude, session: "known", level: nil, age: 80),
+        ]
+
+        let summary = try #require(
+            EffortUsageAggregator.summaries(
+                from: samples,
+                periods: [.today],
+                now: now,
+                calendar: utcCalendar
+            )[.claude]?.first
+        )
+
+        #expect(summary.classifiedSessionCount == 0)
+        #expect(summary.unclassifiedSessionCount == 1)
+        #expect(summary.totalSessionCount == 1)
+    }
+
     @Test func assignsSessionToPeriodUsingItsLatestUsage() throws {
         let eightDays: TimeInterval = 8 * 24 * 60 * 60
         let samples = [

--- a/AgentUsageTests/UsageOrchestrationCollaboratorTests.swift
+++ b/AgentUsageTests/UsageOrchestrationCollaboratorTests.swift
@@ -818,6 +818,61 @@ struct UsageViewModelTokenCoordinationTests {
         #expect(!viewModel.isLoadingTokenUsage)
     }
 
+    @Test @MainActor func failedLocalReadKeepsCachedQuotaProviderUnavailableDetail() async {
+        let testDefaults = TestUserDefaults()
+        let fetchedAt = Date()
+        UsageSnapshotStore(defaults: testDefaults.defaults).save(
+            snapshot: nil,
+            planType: "Free",
+            providerSnapshots: [
+                ProviderUsageSnapshot(
+                    provider: .codex,
+                    windows: [
+                        UsageWindow(
+                            utilization: 42,
+                            resetsAt: fetchedAt.addingTimeInterval(3_600),
+                            windowType: .codexFiveHour
+                        ),
+                    ],
+                    planName: "Plus",
+                    fetchedAt: fetchedAt
+                ),
+            ],
+            fetchedAt: fetchedAt
+        )
+        let tokenSnapshot = TokenUsageCoordinatorTests.makeTokenSnapshot(inputTokens: 0)
+        let coordinator = StubTokenUsageCoordinator(
+            update: TokenUsageRefreshUpdate(
+                snapshot: tokenSnapshot,
+                periodSummaries: [:],
+                selectedPeriodSummary: nil
+            ),
+            details: [:],
+            refreshError: TokenUsageError.fileReadError(
+                NSError(domain: "TokenUsageTests", code: 2)
+            )
+        )
+        let credentials = MockCredentialProvider()
+        await credentials.configure(credentials: MockCredentialProvider.validCredentials())
+        let apiService = MockAPIService()
+        await apiService.setMockSnapshot(Self.makeUsageSnapshot())
+        let viewModel = UsageViewModel(
+            credentialProvider: credentials,
+            apiService: apiService,
+            tokenUsageCoordinator: coordinator,
+            usageHistoryService: UsageHistoryService(defaults: testDefaults.defaults),
+            defaults: testDefaults.defaults
+        )
+
+        #expect(viewModel.providerDetails[.codex]?.hasTokenUsage == false)
+        await viewModel.refresh(force: true)
+
+        #expect(viewModel.usageSnapshot(for: .codex)?.planName == "Plus")
+        #expect(viewModel.providerDetails[.codex]?.hasTokenUsage == false)
+        #expect(viewModel.providerDetails[.codex]?.effortSummaries.isEmpty == true)
+        #expect(viewModel.tokenUsageError != nil)
+    }
+
     @Test @MainActor func enrichedEffortPayloadSurvivesMacRelaunch() async {
         let testDefaults = TestUserDefaults()
         let tokenSnapshot = TokenUsageCoordinatorTests.makeTokenSnapshot(inputTokens: 25)

--- a/AgentUsageTests/UsageOrchestrationCollaboratorTests.swift
+++ b/AgentUsageTests/UsageOrchestrationCollaboratorTests.swift
@@ -415,10 +415,11 @@ struct TokenUsageCoordinatorTests {
             // Expected mapping.
         }
 
+        let stored = try #require(container.mainContext.fetch(FetchDescriptor<TokenLogEntry>()).first)
+        #expect(stored.id == existing.id)
         let samples = try await TokenUsageQuerier(modelContainer: container)
             .fetchEffortUsageSamples(since: .distantPast)
-        #expect(samples.count == 1)
-        #expect(samples.first?.sessionID == "existing-message:existing-request")
+        #expect(samples.isEmpty)
         #expect(
             testDefaults.defaults.integer(forKey: TokenUsageCoordinator.effortMetadataImportedVersionKey)
                 == 0
@@ -509,6 +510,10 @@ struct TokenUsageCoordinatorTests {
 
     @Test @MainActor func firstEffortRefreshBackfillsLegacyRowsAndMarksComplete() async throws {
         let testDefaults = TestUserDefaults()
+        testDefaults.defaults.set(
+            TokenUsageCoordinator.effortMetadataVersion - 1,
+            forKey: TokenUsageCoordinator.effortMetadataImportedVersionKey
+        )
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let container = try Self.makeContainer()
         let legacy = TokenLogEntry(
@@ -524,6 +529,8 @@ struct TokenUsageCoordinatorTests {
         )
         container.mainContext.insert(legacy)
         try container.mainContext.save()
+        #expect(legacy.sessionID == nil)
+        #expect(legacy.isSubagentSession == nil)
 
         let rebuiltEntry = UsageEntry(
             model: "claude-opus-4-6",
@@ -567,6 +574,7 @@ struct TokenUsageCoordinatorTests {
         #expect(samples.count == 1)
         #expect(samples.first?.sessionID == "rebuilt-session")
         #expect(samples.first?.effortLevel == .high)
+        #expect(samples.first?.isSubagentSession == false)
         #expect(
             testDefaults.defaults.integer(forKey: TokenUsageCoordinator.effortMetadataImportedVersionKey)
                 == TokenUsageCoordinator.effortMetadataVersion
@@ -621,6 +629,8 @@ struct TokenUsageCoordinatorTests {
         #expect(details[.claude]?.today.tokens.inputTokens == 25)
         #expect(details[.claude]?.yesterday.tokens.totalTokens == 0)
         #expect(details[.claude]?.dailyCosts == [])
+        #expect(details[.codex]?.hasTokenUsage == true)
+        #expect(details[.claude]?.hasTokenUsage == true)
     }
 
     @Test @MainActor func providerDetailsAttachEffortFromNormalProviderRefresh() async throws {
@@ -668,6 +678,7 @@ struct TokenUsageCoordinatorTests {
         #expect(summary.sessionCount(for: .xhigh) == 0)
         #expect(summary.classifiedSessionCount == 1)
         #expect(summary.unclassifiedSessionCount == 1)
+        #expect(details[.codex]?.hasTokenUsage == false)
     }
 
     private static func makeContainer() throws -> ModelContainer {
@@ -855,6 +866,7 @@ struct UsageViewModelTokenCoordinationTests {
         )
         #expect(relaunched.effortSummary(for: .codex, period: .last30Days) == effortSummary)
         #expect(relaunched.providerDetails[.codex]?.effortSummaries == [effortSummary])
+        #expect(relaunched.providerDetails[.codex]?.hasTokenUsage == false)
     }
 
     private static func makeUsageSnapshot() -> UsageSnapshot {

--- a/AgentUsageTests/UsageViewModelTests.swift
+++ b/AgentUsageTests/UsageViewModelTests.swift
@@ -93,6 +93,11 @@ struct UsageViewModelInitialStateTests {
         #expect(viewModel.hasProviderData(.cursor))
         #expect(!viewModel.hasProviderData(.claude))
         #expect(viewModel.availableProviderSnapshots.map(\.provider) == [.codex, .cursor])
+        #if os(macOS)
+        #expect(viewModel.providerDetails[.codex]?.hasTokenUsage == false)
+        #expect(viewModel.providerDetails[.codex]?.effortSummaries.isEmpty == true)
+        #expect(viewModel.providerDetails[.cursor] == nil)
+        #endif
     }
 
     @Test @MainActor func availableProviderSnapshotsFollowProviderOrderAndBridgeClaude() async {


### PR DESCRIPTION
## Summary

- Preserve migration compatibility for optional Claude session and subagent metadata.
- Ignore effort samples without stable session IDs to prevent inflated session counts.
- Track unavailable token usage separately from genuine zero usage and hide misleading cost/model data.
- Bump effort metadata migration version and expand coverage for legacy rows and provider state.

## Testing

Not run (not requested)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tartinerlabs/codesmith/AgentUsage/pr/95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788181317&installation_model_id=427837&pr_number=95&repository=tartinerlabs%2FAgentUsage&return_to=https%3A%2F%2Fgithub.com%2Ftartinerlabs%2FAgentUsage%2Fpull%2F95&signature=ffb44b12ad04e7e9259d75206fbee7d1741338aaa5378395f35ac23fa70a5972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->