### PR TITLE
Add session-level effort usage tracking to blog sync

### DIFF
--- a/AgentUsage/Models/EffortUsage.swift
+++ b/AgentUsage/Models/EffortUsage.swift
@@ -34,6 +34,14 @@ nonisolated struct EffortUsageSample: Sendable {
     }
 }
 
+/// One normalized session after request-level effort samples are collapsed.
+nonisolated struct EffortSessionSummary: Sendable {
+    let provider: Provider
+    let sessionID: String
+    let latestTimestamp: Date
+    let effortLevel: EffortLevel?
+}
+
 /// Collapses request-level usage into session-count effort distributions.
 nonisolated enum EffortUsageAggregator {
     private struct SessionKey: Hashable {
@@ -53,29 +61,11 @@ nonisolated enum EffortUsageAggregator {
         now: Date = Date(),
         calendar: Calendar = .current
     ) -> [Provider: [EffortPeriodSummary]] {
-        var sessions: [SessionKey: SessionAccumulator] = [:]
-
-        for (index, sample) in samples.enumerated() where !sample.isSubagentSession {
-            // A parser should always supply a stable session id. Keep malformed or
-            // migrated records independent rather than merging every empty id.
-            let sessionID = sample.sessionID.isEmpty
-                ? "legacy-\(index)-\(sample.timestamp.timeIntervalSince1970)"
-                : sample.sessionID
-            let key = SessionKey(provider: sample.provider, sessionID: sessionID)
-            var accumulator = sessions[key] ?? SessionAccumulator(
-                latestTimestamp: sample.timestamp,
-                levelCounts: [:]
-            )
-            accumulator.latestTimestamp = max(accumulator.latestTimestamp, sample.timestamp)
-            if let effortLevel = sample.effortLevel {
-                accumulator.levelCounts[effortLevel, default: 0] += 1
-            }
-            sessions[key] = accumulator
-        }
+        let sessions = sessionSummaries(from: samples)
 
         var result: [Provider: [EffortPeriodSummary]] = [:]
-        for provider in Set(sessions.keys.map(\.provider)) {
-            let providerSessions = sessions.filter { $0.key.provider == provider }.map(\.value)
+        for provider in Set(sessions.map(\.provider)) {
+            let providerSessions = sessions.filter { $0.provider == provider }
             result[provider] = periods.map { period in
                 let startDate = period.startDate(relativeTo: now, calendar: calendar)
                 let inPeriod = providerSessions.filter { $0.latestTimestamp >= startDate }
@@ -83,7 +73,7 @@ nonisolated enum EffortUsageAggregator {
                 var unclassified = 0
 
                 for session in inPeriod {
-                    guard let level = dominantLevel(in: session.levelCounts) else {
+                    guard let level = session.effortLevel else {
                         unclassified += 1
                         continue
                     }
@@ -108,6 +98,43 @@ nonisolated enum EffortUsageAggregator {
             }
         }
         return result
+    }
+
+    /// Exposes the same session semantics to consumers that need non-rolling
+    /// buckets, such as the blog's durable daily aggregates.
+    static func sessionSummaries(from samples: [EffortUsageSample]) -> [EffortSessionSummary] {
+        var sessions: [SessionKey: SessionAccumulator] = [:]
+
+        for (index, sample) in samples.enumerated() where !sample.isSubagentSession {
+            // A parser should always supply a stable session id. Keep malformed or
+            // migrated records independent rather than merging every empty id.
+            let sessionID = sample.sessionID.isEmpty
+                ? "legacy-\(index)-\(sample.timestamp.timeIntervalSince1970)"
+                : sample.sessionID
+            let key = SessionKey(provider: sample.provider, sessionID: sessionID)
+            var accumulator = sessions[key] ?? SessionAccumulator(
+                latestTimestamp: sample.timestamp,
+                levelCounts: [:]
+            )
+            accumulator.latestTimestamp = max(accumulator.latestTimestamp, sample.timestamp)
+            if let effortLevel = sample.effortLevel {
+                accumulator.levelCounts[effortLevel, default: 0] += 1
+            }
+            sessions[key] = accumulator
+        }
+
+        return sessions.map { key, accumulator in
+            EffortSessionSummary(
+                provider: key.provider,
+                sessionID: key.sessionID,
+                latestTimestamp: accumulator.latestTimestamp,
+                effortLevel: dominantLevel(in: accumulator.levelCounts)
+            )
+        }
+        .sorted {
+            if $0.provider != $1.provider { return $0.provider.rawValue < $1.provider.rawValue }
+            return $0.sessionID < $1.sessionID
+        }
     }
 
     private static func dominantLevel(in counts: [EffortLevel: Int]) -> EffortLevel? {

--- a/AgentUsage/Services/BlogUsage/BlogUsageIndexStore.swift
+++ b/AgentUsage/Services/BlogUsage/BlogUsageIndexStore.swift
@@ -5,6 +5,7 @@
 
 #if os(macOS)
 import Foundation
+import AgentUsageKit
 import SQLite3
 
 nonisolated enum BlogUsageIndexedSource: String, Sendable {
@@ -21,9 +22,39 @@ nonisolated struct BlogUsageFileCheckpoint: Sendable, Equatable {
     let modificationTime: TimeInterval
     let byteOffset: Int64
     let currentModel: String
+    let currentEffortLevelRaw: String?
+    let isSubagentSession: Bool
     let tailHash: String
     let sampleHash: String?
     let isComplete: Bool
+
+    init(
+        source: BlogUsageIndexedSource,
+        path: String,
+        fileIdentifier: String?,
+        fileSize: Int64,
+        modificationTime: TimeInterval,
+        byteOffset: Int64,
+        currentModel: String,
+        currentEffortLevelRaw: String? = nil,
+        isSubagentSession: Bool = false,
+        tailHash: String,
+        sampleHash: String?,
+        isComplete: Bool
+    ) {
+        self.source = source
+        self.path = path
+        self.fileIdentifier = fileIdentifier
+        self.fileSize = fileSize
+        self.modificationTime = modificationTime
+        self.byteOffset = byteOffset
+        self.currentModel = currentModel
+        self.currentEffortLevelRaw = currentEffortLevelRaw
+        self.isSubagentSession = isSubagentSession
+        self.tailHash = tailHash
+        self.sampleHash = sampleHash
+        self.isComplete = isComplete
+    }
 }
 
 nonisolated enum BlogUsageIndexStoreError: LocalizedError, Sendable {
@@ -62,6 +93,7 @@ nonisolated protocol BlogUsageIndexStoring: AnyObject, Sendable {
     func deleteRecord(source: BlogUsageIndexedSource, container: String, recordKey: String) throws -> Bool
     func deleteRecords(source: BlogUsageIndexedSource, container: String) throws -> Bool
     func aggregateRows() throws -> [BlogUsageIngestRow]
+    func effortUsageSamples() throws -> [EffortUsageSample]
     func recordCount() throws -> Int
     func revision() throws -> Int64
     /// Callers commonly want only the side effect of bumping the revision.
@@ -77,7 +109,7 @@ nonisolated protocol BlogUsageIndexStoring: AnyObject, Sendable {
 /// The class is `@unchecked Sendable` only so it can be injected into that actor;
 /// all access remains serialized by the actor.
 final class BlogUsageIndexStore: BlogUsageIndexStoring, @unchecked Sendable {
-    private static let schemaVersion: Int32 = 1
+    private static let schemaVersion: Int32 = 2
 
     private let databaseURL: URL
     private let timeZoneIdentifier: String
@@ -126,7 +158,8 @@ final class BlogUsageIndexStore: BlogUsageIndexStoring, @unchecked Sendable {
     func checkpoint(path: String) throws -> BlogUsageFileCheckpoint? {
         let sql = """
         SELECT source, path, file_identifier, file_size, modification_time,
-               byte_offset, current_model, tail_hash, sample_hash, is_complete
+               byte_offset, current_model, current_effort_level, is_subagent_session,
+               tail_hash, sample_hash, is_complete
         FROM source_files WHERE path = ? LIMIT 1
         """
         let statement = try prepare(sql)
@@ -146,7 +179,8 @@ final class BlogUsageIndexStore: BlogUsageIndexStoring, @unchecked Sendable {
     func checkpoints() throws -> [BlogUsageFileCheckpoint] {
         let statement = try prepare("""
         SELECT source, path, file_identifier, file_size, modification_time,
-               byte_offset, current_model, tail_hash, sample_hash, is_complete
+               byte_offset, current_model, current_effort_level, is_subagent_session,
+               tail_hash, sample_hash, is_complete
         FROM source_files
         """)
         defer { sqlite3_finalize(statement) }
@@ -170,8 +204,9 @@ final class BlogUsageIndexStore: BlogUsageIndexStoring, @unchecked Sendable {
         let statement = try prepare("""
         INSERT INTO source_files (
             source, path, file_identifier, file_size, modification_time,
-            byte_offset, current_model, tail_hash, sample_hash, is_complete
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            byte_offset, current_model, current_effort_level, is_subagent_session,
+            tail_hash, sample_hash, is_complete
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(path) DO UPDATE SET
             source = excluded.source,
             file_identifier = excluded.file_identifier,
@@ -179,6 +214,8 @@ final class BlogUsageIndexStore: BlogUsageIndexStoring, @unchecked Sendable {
             modification_time = excluded.modification_time,
             byte_offset = excluded.byte_offset,
             current_model = excluded.current_model,
+            current_effort_level = excluded.current_effort_level,
+            is_subagent_session = excluded.is_subagent_session,
             tail_hash = excluded.tail_hash,
             sample_hash = excluded.sample_hash,
             is_complete = excluded.is_complete
@@ -192,9 +229,11 @@ final class BlogUsageIndexStore: BlogUsageIndexStoring, @unchecked Sendable {
         sqlite3_bind_double(statement, 5, checkpoint.modificationTime)
         sqlite3_bind_int64(statement, 6, checkpoint.byteOffset)
         bind(checkpoint.currentModel, to: 7, in: statement)
-        bind(checkpoint.tailHash, to: 8, in: statement)
-        bind(checkpoint.sampleHash, to: 9, in: statement)
-        sqlite3_bind_int(statement, 10, checkpoint.isComplete ? 1 : 0)
+        bind(checkpoint.currentEffortLevelRaw, to: 8, in: statement)
+        sqlite3_bind_int(statement, 9, checkpoint.isSubagentSession ? 1 : 0)
+        bind(checkpoint.tailHash, to: 10, in: statement)
+        bind(checkpoint.sampleHash, to: 11, in: statement)
+        sqlite3_bind_int(statement, 12, checkpoint.isComplete ? 1 : 0)
         try finish(statement)
     }
 
@@ -224,8 +263,9 @@ final class BlogUsageIndexStore: BlogUsageIndexStoring, @unchecked Sendable {
         INSERT INTO usage_records (
             source, container, record_key, dedupe_key, timestamp, date,
             agent, provider, model, input_tokens, output_tokens,
-            cache_read_tokens, cache_write_tokens, reasoning_tokens
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            session_id, effort_level, is_subagent_session
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(source, container, record_key) DO UPDATE SET
             dedupe_key = excluded.dedupe_key,
             timestamp = excluded.timestamp,
@@ -237,7 +277,10 @@ final class BlogUsageIndexStore: BlogUsageIndexStoring, @unchecked Sendable {
             output_tokens = excluded.output_tokens,
             cache_read_tokens = excluded.cache_read_tokens,
             cache_write_tokens = excluded.cache_write_tokens,
-            reasoning_tokens = excluded.reasoning_tokens
+            reasoning_tokens = excluded.reasoning_tokens,
+            session_id = excluded.session_id,
+            effort_level = excluded.effort_level,
+            is_subagent_session = excluded.is_subagent_session
         """)
         defer { sqlite3_finalize(statement) }
 
@@ -255,6 +298,9 @@ final class BlogUsageIndexStore: BlogUsageIndexStoring, @unchecked Sendable {
         sqlite3_bind_int64(statement, 12, Int64(event.cacheReadTokens))
         sqlite3_bind_int64(statement, 13, Int64(event.cacheWriteTokens))
         sqlite3_bind_int64(statement, 14, Int64(event.reasoningTokens))
+        bind(event.sessionID, to: 15, in: statement)
+        bind(event.effortLevel?.rawValue, to: 16, in: statement)
+        sqlite3_bind_int(statement, 17, event.isSubagentSession ? 1 : 0)
         try finish(statement)
         return sqlite3_changes(database) > 0
     }
@@ -352,6 +398,97 @@ final class BlogUsageIndexStore: BlogUsageIndexStoring, @unchecked Sendable {
                 ))
             case SQLITE_DONE:
                 return rows
+            default:
+                throw stepError()
+            }
+        }
+    }
+
+    func effortUsageSamples() throws -> [EffortUsageSample] {
+        // Claude contributes its canonical request records so the common
+        // aggregator can choose a dominant session effort. Codex contributes
+        // one latest record per session, paired with the file checkpoint's
+        // latest effort/subagent state to mirror CodexLogSource semantics.
+        let statement = try prepare("""
+        WITH canonical AS (
+            SELECT record.*
+            FROM usage_records AS record
+            WHERE record.dedupe_key IS NULL
+               OR NOT EXISTS (
+                    SELECT 1
+                    FROM usage_records AS earlier
+                    WHERE earlier.source = record.source
+                      AND earlier.dedupe_key = record.dedupe_key
+                      AND (
+                          earlier.container < record.container
+                          OR (earlier.container = record.container AND earlier.record_key < record.record_key)
+                      )
+               )
+        ),
+        latest_codex AS (
+            SELECT record.*,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY record.session_id
+                       ORDER BY record.timestamp DESC,
+                                record.container DESC,
+                                record.record_key DESC
+                   ) AS session_rank
+            FROM canonical AS record
+            WHERE record.source = 'codex'
+        ),
+        effort_samples AS (
+            SELECT source, session_id, effort_level, timestamp, is_subagent_session
+            FROM canonical
+            WHERE source = 'claude'
+
+            UNION ALL
+
+            SELECT latest.source,
+                   latest.session_id,
+                   CASE
+                       WHEN file.path IS NULL THEN latest.effort_level
+                       ELSE file.current_effort_level
+                   END,
+                   latest.timestamp,
+                   CASE
+                       WHEN file.path IS NULL THEN latest.is_subagent_session
+                       ELSE file.is_subagent_session
+                   END
+            FROM latest_codex AS latest
+            LEFT JOIN source_files AS file ON file.path = latest.container
+            WHERE latest.session_rank = 1
+        )
+        SELECT source, session_id, effort_level, timestamp, is_subagent_session
+        FROM effort_samples
+        ORDER BY source, session_id, timestamp
+        """)
+        defer { sqlite3_finalize(statement) }
+
+        var samples: [EffortUsageSample] = []
+        while true {
+            switch sqlite3_step(statement) {
+            case SQLITE_ROW:
+                guard let sourceValue = columnString(statement, index: 0),
+                      let source = BlogUsageIndexedSource(rawValue: sourceValue) else {
+                    continue
+                }
+                let provider: Provider
+                switch source {
+                case .claude: provider = .claude
+                case .codex: provider = .codex
+                case .openCode: continue
+                }
+                let effortLevel = columnString(statement, index: 2)
+                    .map(EffortLevel.init(rawValue:))
+                samples.append(EffortUsageSample(
+                    provider: provider,
+                    sessionID: columnString(statement, index: 1) ?? "",
+                    effortLevel: effortLevel,
+                    timestamp: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
+                    isSubagentSession: sqlite3_column_int(statement, 4) != 0
+                ))
+            case SQLITE_DONE:
+                return samples
             default:
                 throw stepError()
             }
@@ -467,6 +604,8 @@ final class BlogUsageIndexStore: BlogUsageIndexStoring, @unchecked Sendable {
             modification_time REAL NOT NULL,
             byte_offset INTEGER NOT NULL,
             current_model TEXT NOT NULL,
+            current_effort_level TEXT,
+            is_subagent_session INTEGER NOT NULL,
             tail_hash TEXT NOT NULL,
             sample_hash TEXT,
             is_complete INTEGER NOT NULL
@@ -488,6 +627,9 @@ final class BlogUsageIndexStore: BlogUsageIndexStoring, @unchecked Sendable {
             cache_read_tokens INTEGER NOT NULL,
             cache_write_tokens INTEGER NOT NULL,
             reasoning_tokens INTEGER NOT NULL,
+            session_id TEXT NOT NULL,
+            effort_level TEXT,
+            is_subagent_session INTEGER NOT NULL,
             PRIMARY KEY (source, container, record_key)
         )
         """)
@@ -560,9 +702,11 @@ final class BlogUsageIndexStore: BlogUsageIndexStoring, @unchecked Sendable {
             modificationTime: sqlite3_column_double(statement, 4),
             byteOffset: sqlite3_column_int64(statement, 5),
             currentModel: columnString(statement, index: 6) ?? "unknown",
-            tailHash: columnString(statement, index: 7) ?? "",
-            sampleHash: columnString(statement, index: 8),
-            isComplete: sqlite3_column_int(statement, 9) != 0
+            currentEffortLevelRaw: columnString(statement, index: 7),
+            isSubagentSession: sqlite3_column_int(statement, 8) != 0,
+            tailHash: columnString(statement, index: 9) ?? "",
+            sampleHash: columnString(statement, index: 10),
+            isComplete: sqlite3_column_int(statement, 11) != 0
         )
     }
 

--- a/AgentUsage/Services/BlogUsage/BlogUsageSourceIndexer.swift
+++ b/AgentUsage/Services/BlogUsage/BlogUsageSourceIndexer.swift
@@ -6,6 +6,7 @@
 #if os(macOS)
 import CryptoKit
 import Foundation
+import AgentUsageKit
 import OSLog
 import SQLite3
 
@@ -27,6 +28,7 @@ nonisolated struct BlogUsageIndexResult: Sendable, Equatable {
 nonisolated protocol BlogUsageIndexing: Sendable {
     func index(maximumBytes: Int) async throws -> BlogUsageIndexResult
     func rows() async throws -> [BlogUsageIngestRow]
+    func effortRows() async throws -> [BlogUsageEffortIngestRow]
     func revision() async throws -> Int64
     func uploadedRevision(endpoint: String) async throws -> Int64
     func markUploaded(revision: Int64, endpoint: String) async throws
@@ -120,6 +122,10 @@ actor BlogUsageSourceIndexer: BlogUsageIndexing {
 
     func rows() throws -> [BlogUsageIngestRow] {
         try store().aggregateRows()
+    }
+
+    func effortRows() throws -> [BlogUsageEffortIngestRow] {
+        BlogUsageEffortAggregator.aggregate(try store().effortUsageSamples())
     }
 
     func revision() throws -> Int64 {
@@ -232,6 +238,8 @@ actor BlogUsageSourceIndexer: BlogUsageIndexing {
                         modificationTime: file.modificationDate.timeIntervalSince1970,
                         byteOffset: match.byteOffset,
                         currentModel: match.currentModel,
+                        currentEffortLevelRaw: match.currentEffortLevelRaw,
+                        isSubagentSession: match.isSubagentSession,
                         tailHash: match.tailHash,
                         sampleHash: match.sampleHash,
                         isComplete: match.isComplete
@@ -278,6 +286,11 @@ actor BlogUsageSourceIndexer: BlogUsageIndexing {
         let checkpoint = try validatedCheckpoint(for: file, store: store)
         let startOffset = checkpoint?.byteOffset ?? 0
         var currentModel = checkpoint?.currentModel ?? "unknown"
+        var currentEffortLevel = checkpoint?.currentEffortLevelRaw
+            .map(EffortLevel.init(rawValue:))
+        var isSubagentSession = checkpoint?.isSubagentSession ?? false
+        let initialEffortLevelRaw = checkpoint?.currentEffortLevelRaw
+        let initialIsSubagentSession = checkpoint?.isSubagentSession ?? false
         guard let handle = try? FileHandle(forReadingFrom: file.url) else {
             return .unreadable
         }
@@ -321,6 +334,8 @@ actor BlogUsageSourceIndexer: BlogUsageIndexing {
                         container: file.url.path,
                         byteOffset: pendingOffset + Int64(relativeOffset),
                         currentModel: &currentModel,
+                        currentEffortLevel: &currentEffortLevel,
+                        isSubagentSession: &isSubagentSession,
                         store: store
                     ) {
                         changedRecords += 1
@@ -362,12 +377,17 @@ actor BlogUsageSourceIndexer: BlogUsageIndexing {
                 modificationTime: file.modificationDate.timeIntervalSince1970,
                 byteOffset: pendingOffset,
                 currentModel: currentModel,
+                currentEffortLevelRaw: currentEffortLevel?.rawValue,
+                isSubagentSession: isSubagentSession,
                 tailHash: try tailHash(of: file.url, endingAt: pendingOffset),
                 sampleHash: reachedEnd ? try sampledHash(of: file.url, size: file.fileSize) : checkpoint?.sampleHash,
                 isComplete: reachedEnd
             )
             try store.saveCheckpoint(updatedCheckpoint)
-            if changedRecords > 0 {
+            let effortMetadataChanged = file.source == .codex
+                && (currentEffortLevel?.rawValue != initialEffortLevelRaw
+                    || isSubagentSession != initialIsSubagentSession)
+            if changedRecords > 0 || effortMetadataChanged {
                 try store.advanceRevision()
             }
         }
@@ -415,6 +435,8 @@ actor BlogUsageSourceIndexer: BlogUsageIndexing {
                 modificationTime: file.modificationDate.timeIntervalSince1970,
                 byteOffset: 0,
                 currentModel: "unknown",
+                currentEffortLevelRaw: nil,
+                isSubagentSession: false,
                 tailHash: "",
                 sampleHash: nil,
                 isComplete: false
@@ -430,12 +452,23 @@ actor BlogUsageSourceIndexer: BlogUsageIndexing {
         container: String,
         byteOffset: Int64,
         currentModel: inout String,
+        currentEffortLevel: inout EffortLevel?,
+        isSubagentSession: inout Bool,
         store: any BlogUsageIndexStoring
     ) throws -> Bool {
         let recordKey = String(format: "%020lld", byteOffset)
         switch source {
         case .claude:
-            guard let parsed = autoreleasepool(invoking: { parser.parseClaudeLine(data) }) else {
+            let fallbackSessionID = URL(fileURLWithPath: container)
+                .deletingPathExtension().lastPathComponent
+            let isSubagent = URL(fileURLWithPath: container).pathComponents.contains("subagents")
+            guard let parsed = autoreleasepool(invoking: {
+                parser.parseClaudeLine(
+                    data,
+                    fallbackSessionID: fallbackSessionID,
+                    isSubagentSession: isSubagent
+                )
+            }) else {
                 return false
             }
             return try store.replaceRecord(
@@ -446,8 +479,15 @@ actor BlogUsageSourceIndexer: BlogUsageIndexing {
                 event: parsed.event
             )
         case .codex:
+            let sessionID = parser.codexSessionIdentifier(for: URL(fileURLWithPath: container))
             guard let event = autoreleasepool(invoking: {
-                parser.parseCodexLine(data, currentModel: &currentModel)
+                parser.parseCodexLine(
+                    data,
+                    currentModel: &currentModel,
+                    currentEffortLevel: &currentEffortLevel,
+                    isSubagentSession: &isSubagentSession,
+                    sessionID: sessionID
+                )
             }) else {
                 return false
             }

--- a/AgentUsage/Services/BlogUsage/BlogUsageSyncService.swift
+++ b/AgentUsage/Services/BlogUsage/BlogUsageSyncService.swift
@@ -6,6 +6,7 @@
 #if os(macOS)
 import CryptoKit
 import Foundation
+import AgentUsageKit
 import SQLite3
 
 nonisolated struct BlogUsageEvent: Sendable, Equatable {
@@ -19,6 +20,40 @@ nonisolated struct BlogUsageEvent: Sendable, Equatable {
     let cacheReadTokens: Int
     let cacheWriteTokens: Int
     let reasoningTokens: Int
+    /// Stable local session identity used only to build privacy-preserving aggregates.
+    let sessionID: String
+    let effortLevel: EffortLevel?
+    let isSubagentSession: Bool
+
+    init(
+        id: String,
+        timestamp: Date,
+        agent: String,
+        provider: String,
+        model: String,
+        inputTokens: Int,
+        outputTokens: Int,
+        cacheReadTokens: Int,
+        cacheWriteTokens: Int,
+        reasoningTokens: Int,
+        sessionID: String = "",
+        effortLevel: EffortLevel? = nil,
+        isSubagentSession: Bool = false
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.agent = agent
+        self.provider = provider
+        self.model = model
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.cacheReadTokens = cacheReadTokens
+        self.cacheWriteTokens = cacheWriteTokens
+        self.reasoningTokens = reasoningTokens
+        self.sessionID = sessionID
+        self.effortLevel = effortLevel
+        self.isSubagentSession = isSubagentSession
+    }
 }
 
 nonisolated struct BlogUsageIngestRow: Codable, Sendable, Equatable {
@@ -74,6 +109,19 @@ nonisolated struct BlogUsageIngestRow: Codable, Sendable, Equatable {
 
 nonisolated struct BlogUsageIngestPayload: Codable, Sendable, Equatable {
     let rows: [BlogUsageIngestRow]
+    /// Full daily snapshot when true; partial backfill rows when false.
+    let effortRows: [BlogUsageEffortIngestRow]
+    let effortSnapshotComplete: Bool
+}
+
+/// A daily session-level effort summary. This remains separate from token rows:
+/// token rows count requests, while effort usage deliberately counts sessions.
+nonisolated struct BlogUsageEffortIngestRow: Codable, Sendable, Equatable {
+    let date: String
+    let agent: String
+    let levels: [EffortLevelCount]
+    let classifiedSessionCount: Int
+    let unclassifiedSessionCount: Int
 }
 
 nonisolated enum BlogUsageSyncState: String, Codable, Sendable {
@@ -246,6 +294,63 @@ nonisolated struct BlogUsageAggregator {
     }
 }
 
+nonisolated enum BlogUsageEffortAggregator {
+    private struct Key: Hashable {
+        let date: String
+        let agent: String
+    }
+
+    private struct Counts {
+        var levels: [EffortLevel: Int] = [:]
+        var unclassified = 0
+    }
+
+    static func aggregate(
+        _ samples: [EffortUsageSample],
+        calendar: Calendar = .current
+    ) -> [BlogUsageEffortIngestRow] {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = calendar.timeZone
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        var buckets: [Key: Counts] = [:]
+        for session in EffortUsageAggregator.sessionSummaries(from: samples) {
+            let key = Key(
+                date: formatter.string(from: session.latestTimestamp),
+                agent: session.provider.rawValue
+            )
+            var counts = buckets[key] ?? Counts()
+            if let effortLevel = session.effortLevel {
+                counts.levels[effortLevel, default: 0] += 1
+            } else {
+                counts.unclassified += 1
+            }
+            buckets[key] = counts
+        }
+
+        return buckets.map { key, counts in
+            let levels = counts.levels
+                .map { EffortLevelCount(level: $0.key, sessionCount: $0.value) }
+                .sorted {
+                    if $0.level.sortOrder == $1.level.sortOrder {
+                        return $0.level.rawValue < $1.level.rawValue
+                    }
+                    return $0.level.sortOrder < $1.level.sortOrder
+                }
+            return BlogUsageEffortIngestRow(
+                date: key.date,
+                agent: key.agent,
+                levels: levels,
+                classifiedSessionCount: counts.levels.values.reduce(0, +),
+                unclassifiedSessionCount: counts.unclassified
+            )
+        }
+        .sorted { ($0.date, $0.agent) < ($1.date, $1.agent) }
+    }
+}
+
 nonisolated struct BlogUsageSourceParser {
     let fileManager: FileManager
     let homeDirectory: URL
@@ -296,7 +401,11 @@ nonisolated struct BlogUsageSourceParser {
 
         for file in files {
             for line in try lines(in: file) {
-                guard let parsed = parseClaudeLine(Data(line.utf8)) else { continue }
+                guard let parsed = parseClaudeLine(
+                    Data(line.utf8),
+                    fallbackSessionID: file.deletingPathExtension().lastPathComponent,
+                    isSubagentSession: file.pathComponents.contains("subagents")
+                ) else { continue }
                 guard seen.insert(parsed.dedupeID).inserted else { continue }
                 events.append(parsed.event)
             }
@@ -316,8 +425,17 @@ nonisolated struct BlogUsageSourceParser {
 
         for file in files {
             var currentModel = "unknown"
+            var currentEffortLevel: EffortLevel?
+            var isSubagentSession = false
+            let sessionID = codexSessionIdentifier(for: file)
             for line in try lines(in: file) {
-                if let event = parseCodexLine(Data(line.utf8), currentModel: &currentModel) {
+                if let event = parseCodexLine(
+                    Data(line.utf8),
+                    currentModel: &currentModel,
+                    currentEffortLevel: &currentEffortLevel,
+                    isSubagentSession: &isSubagentSession,
+                    sessionID: sessionID
+                ) {
                     events.append(event)
                 }
             }
@@ -326,7 +444,13 @@ nonisolated struct BlogUsageSourceParser {
         return events
     }
 
-    nonisolated func parseCodexLine(_ data: Data, currentModel: inout String) -> BlogUsageEvent? {
+    nonisolated func parseCodexLine(
+        _ data: Data,
+        currentModel: inout String,
+        currentEffortLevel: inout EffortLevel?,
+        isSubagentSession: inout Bool,
+        sessionID: String
+    ) -> BlogUsageEvent? {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let payload = json["payload"] as? [String: Any] else {
             return nil
@@ -334,6 +458,15 @@ nonisolated struct BlogUsageSourceParser {
 
         if let model = payload["model"] as? String, !model.isEmpty {
             currentModel = model
+            // A new turn context supersedes the previous setting. Missing effort
+            // therefore means explicitly unclassified until another context appears.
+            currentEffortLevel = Self.normalizedEffortLevel(payload["effort"])
+        }
+
+        if json["type"] as? String == "session_meta" {
+            let source = payload["source"] as? [String: Any]
+            isSubagentSession = payload["thread_source"] as? String == "subagent"
+                || source?["subagent"] != nil
         }
 
         guard let type = payload["type"] as? String,
@@ -364,7 +497,10 @@ nonisolated struct BlogUsageSourceParser {
             outputTokens: max(0, outputTokensRaw - reasoningTokens),
             cacheReadTokens: max(0, cachedInputTokens),
             cacheWriteTokens: 0,
-            reasoningTokens: max(0, reasoningTokens)
+            reasoningTokens: max(0, reasoningTokens),
+            sessionID: sessionID,
+            effortLevel: currentEffortLevel,
+            isSubagentSession: isSubagentSession
         )
     }
 
@@ -374,7 +510,11 @@ nonisolated struct BlogUsageSourceParser {
         return try OpenCodeDatabaseReader(databaseURL: databaseURL, now: now).readEvents()
     }
 
-    nonisolated func parseClaudeLine(_ data: Data) -> (event: BlogUsageEvent, dedupeID: String)? {
+    nonisolated func parseClaudeLine(
+        _ data: Data,
+        fallbackSessionID: String = "",
+        isSubagentSession: Bool = false
+    ) -> (event: BlogUsageEvent, dedupeID: String)? {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let type = json["type"] as? String,
               type == "assistant",
@@ -391,6 +531,10 @@ nonisolated struct BlogUsageSourceParser {
             ?? stringValue(json["request_id"])
             ?? stringValue(json["uuid"])
             ?? stableHash(data)
+        let recordedSessionID = stringValue(json["sessionId"])?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let sessionID = recordedSessionID.flatMap { $0.isEmpty ? nil : $0 }
+            ?? fallbackSessionID
 
         let event = BlogUsageEvent(
             id: "claude-\(dedupeID)",
@@ -402,7 +546,10 @@ nonisolated struct BlogUsageSourceParser {
             outputTokens: intValue(usage["output_tokens"]),
             cacheReadTokens: intValue(usage["cache_read_input_tokens"]),
             cacheWriteTokens: intValue(usage["cache_creation_input_tokens"]),
-            reasoningTokens: 0
+            reasoningTokens: 0,
+            sessionID: sessionID,
+            effortLevel: Self.normalizedEffortLevel(json["effort"]),
+            isSubagentSession: isSubagentSession
         )
 
         return (event, dedupeID)
@@ -458,6 +605,18 @@ nonisolated struct BlogUsageSourceParser {
             return URL(fileURLWithPath: xdgDataHome).appendingPathComponent("opencode/opencode.db")
         }
         return homeDirectory.appendingPathComponent(".local/share/opencode/opencode.db")
+    }
+
+    nonisolated func codexSessionIdentifier(for url: URL) -> String {
+        let stem = url.deletingPathExtension().lastPathComponent
+        let candidate = String(stem.suffix(36))
+        return UUID(uuidString: candidate) == nil ? stem : candidate.lowercased()
+    }
+
+    private nonisolated static func normalizedEffortLevel(_ value: Any?) -> EffortLevel? {
+        guard let rawValue = value as? String else { return nil }
+        let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.isEmpty ? nil : EffortLevel(rawValue: normalized)
     }
 
     private nonisolated func jsonlFiles(in root: URL) throws -> [URL] {
@@ -654,7 +813,13 @@ nonisolated struct BlogUsageSourceParser {
 }
 
 nonisolated protocol BlogUsageSyncPosting: Sendable {
-    nonisolated func post(rows: [BlogUsageIngestRow], endpoint: URL, token: String) async throws
+    nonisolated func post(
+        rows: [BlogUsageIngestRow],
+        effortRows: [BlogUsageEffortIngestRow],
+        effortSnapshotComplete: Bool,
+        endpoint: URL,
+        token: String
+    ) async throws
 }
 
 nonisolated struct BlogUsageSyncClient: BlogUsageSyncPosting {
@@ -666,12 +831,22 @@ nonisolated struct BlogUsageSyncClient: BlogUsageSyncPosting {
         self.encoder = JSONEncoder()
     }
 
-    nonisolated func post(rows: [BlogUsageIngestRow], endpoint: URL, token: String) async throws {
+    nonisolated func post(
+        rows: [BlogUsageIngestRow],
+        effortRows: [BlogUsageEffortIngestRow],
+        effortSnapshotComplete: Bool,
+        endpoint: URL,
+        token: String
+    ) async throws {
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "content-type")
         request.setValue("Bearer \(token)", forHTTPHeaderField: "authorization")
-        request.httpBody = try encoder.encode(BlogUsageIngestPayload(rows: rows))
+        request.httpBody = try encoder.encode(BlogUsageIngestPayload(
+            rows: rows,
+            effortRows: effortRows,
+            effortSnapshotComplete: effortSnapshotComplete
+        ))
 
         let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -856,7 +1031,9 @@ actor BlogUsageSyncService {
 
             let rows = try await indexer.rows()
             guard !rows.isEmpty else {
-                try await indexer.markUploaded(revision: revision, endpoint: endpoint.absoluteString)
+                if !indexResult.isBackfillInProgress {
+                    try await indexer.markUploaded(revision: revision, endpoint: endpoint.absoluteString)
+                }
                 return updateStatus(
                     .success,
                     message: indexResult.isBackfillInProgress
@@ -866,8 +1043,20 @@ actor BlogUsageSyncService {
                 )
             }
 
-            try await client.post(rows: rows, endpoint: endpoint, token: token)
-            try await indexer.markUploaded(revision: revision, endpoint: endpoint.absoluteString)
+            let effortRows = try await indexer.effortRows()
+            try await client.post(
+                rows: rows,
+                effortRows: effortRows,
+                effortSnapshotComplete: !indexResult.isBackfillInProgress,
+                endpoint: endpoint,
+                token: token
+            )
+            // A partial daily effort snapshot cannot be treated as uploaded:
+            // the final indexing pass may only cross EOF and leave the token
+            // revision unchanged, but still must publish snapshot-complete=true.
+            if !indexResult.isBackfillInProgress {
+                try await indexer.markUploaded(revision: revision, endpoint: endpoint.absoluteString)
+            }
             let suffix = indexResult.isBackfillInProgress
                 ? "; indexing history (\(indexResult.remainingSources) source\(indexResult.remainingSources == 1 ? "" : "s") remaining)"
                 : ""

--- a/AgentUsageTests/BlogUsageSyncTests.swift
+++ b/AgentUsageTests/BlogUsageSyncTests.swift
@@ -5,6 +5,7 @@
 
 #if os(macOS)
 import Foundation
+import AgentUsageKit
 import SQLite3
 import Testing
 @testable import AgentUsage
@@ -57,7 +58,7 @@ struct BlogUsageSyncTests {
         try FileManager.default.createDirectory(at: logDirectory, withIntermediateDirectories: true)
         let log = logDirectory.appendingPathComponent("session.jsonl")
         try """
-        {"timestamp":"2026-06-02T10:00:00Z","payload":{"model":"gpt-5"}}
+        {"timestamp":"2026-06-02T10:00:00Z","payload":{"model":"gpt-5","effort":"  XHIGH  "}}
         {"timestamp":"2026-06-02T10:01:00Z","payload":{"type":"token_count","id":"usage-1","info":{"last_token_usage":{"input_tokens":1000,"cached_input_tokens":250,"output_tokens":700,"reasoning_output_tokens":200}}}}
         """.write(to: log, atomically: true, encoding: .utf8)
 
@@ -73,6 +74,43 @@ struct BlogUsageSyncTests {
         #expect(events.first?.outputTokens == 500)
         #expect(events.first?.reasoningTokens == 200)
         #expect(events.first?.cacheWriteTokens == 0)
+        #expect(events.first?.effortLevel == .xhigh)
+        #expect(events.first?.sessionID == "session")
+    }
+
+    @Test func claudeParserNormalizesEffortAndTracksSessionMetadata() throws {
+        let parser = BlogUsageSourceParser(homeDirectory: try Self.temporaryDirectory(), environment: [:])
+        let line = Data("""
+        {"type":"assistant","timestamp":"2026-06-02T10:00:00Z","sessionId":"  session-1  ","effort":"  Adaptive-Plus  ","message":{"id":"msg-1","model":"claude-sonnet-4-5","usage":{"input_tokens":1,"output_tokens":2}}}
+        """.utf8)
+
+        let parsed = try #require(parser.parseClaudeLine(
+            line,
+            fallbackSessionID: "fallback",
+            isSubagentSession: true
+        ))
+
+        #expect(parsed.event.sessionID == "session-1")
+        #expect(parsed.event.effortLevel?.rawValue == "adaptive-plus")
+        #expect(parsed.event.isSubagentSession)
+    }
+
+    @Test func codexParserClearsEffortWhenANewTurnContextOmitsIt() throws {
+        let home = try Self.temporaryDirectory()
+        let logDirectory = home.appendingPathComponent(".codex/sessions/2026/06", isDirectory: true)
+        try FileManager.default.createDirectory(at: logDirectory, withIntermediateDirectories: true)
+        let log = logDirectory.appendingPathComponent("session.jsonl")
+        try """
+        {"timestamp":"2026-06-02T10:00:00Z","payload":{"model":"gpt-5","effort":" HIGH "}}
+        {"timestamp":"2026-06-02T10:01:00Z","payload":{"type":"token_count","id":"usage-1","info":{"last_token_usage":{"input_tokens":1}}}}
+        {"timestamp":"2026-06-02T10:02:00Z","payload":{"model":"gpt-5"}}
+        {"timestamp":"2026-06-02T10:03:00Z","payload":{"type":"token_count","id":"usage-2","info":{"last_token_usage":{"input_tokens":1}}}}
+        """.write(to: log, atomically: true, encoding: .utf8)
+
+        let events = try BlogUsageSourceParser(homeDirectory: home, environment: [:])
+            .parseCodexEvents()
+
+        #expect(events.map(\.effortLevel) == [.high, nil])
     }
 
     @Test func openCodeParserMapsOpenCodeGoProviderModelTimestampAndTokens() throws {
@@ -270,6 +308,53 @@ struct BlogUsageSyncTests {
         #expect(rows.first?.costUsd == nil)
     }
 
+    @Test func effortAggregatorUsesDominantSessionLevelAndExcludesSubagents() throws {
+        let timestamp = try #require(ISO8601DateFormatter().date(from: "2026-06-02T12:00:00Z"))
+        let samples = [
+            EffortUsageSample(
+                provider: .claude,
+                sessionID: "dominant",
+                effortLevel: .high,
+                timestamp: timestamp.addingTimeInterval(-60)
+            ),
+            EffortUsageSample(
+                provider: .claude,
+                sessionID: "dominant",
+                effortLevel: .high,
+                timestamp: timestamp.addingTimeInterval(-50)
+            ),
+            EffortUsageSample(
+                provider: .claude,
+                sessionID: "dominant",
+                effortLevel: .low,
+                timestamp: timestamp.addingTimeInterval(-40)
+            ),
+            EffortUsageSample(
+                provider: .claude,
+                sessionID: "unclassified",
+                effortLevel: nil,
+                timestamp: timestamp.addingTimeInterval(-30)
+            ),
+            EffortUsageSample(
+                provider: .codex,
+                sessionID: "subagent",
+                effortLevel: .ultra,
+                timestamp: timestamp.addingTimeInterval(-20),
+                isSubagentSession: true
+            )
+        ]
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+
+        let rows = BlogUsageEffortAggregator.aggregate(samples, calendar: calendar)
+        let day = try #require(rows.first { $0.agent == "claude" && $0.date == "2026-06-02" })
+
+        #expect(day.levels == [EffortLevelCount(level: .high, sessionCount: 1)])
+        #expect(day.classifiedSessionCount == 1)
+        #expect(day.unclassifiedSessionCount == 1)
+        #expect(!rows.contains { $0.agent == "codex" })
+    }
+
     @Test func syncClientSendsBearerAuthAndWrappedRows() async throws {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [BlogUsageURLProtocol.self]
@@ -289,6 +374,13 @@ struct BlogUsageSyncTests {
             costUsd: nil,
             messages: 1
         )
+        let effortRow = BlogUsageEffortIngestRow(
+            date: "2026-06-02",
+            agent: "claude",
+            levels: [EffortLevelCount(level: .high, sessionCount: 2)],
+            classifiedSessionCount: 2,
+            unclassifiedSessionCount: 1
+        )
 
         BlogUsageURLProtocol.handler = { request in
             #expect(request.value(forHTTPHeaderField: "authorization") == "Bearer test-token")
@@ -298,13 +390,24 @@ struct BlogUsageSyncTests {
             let rawRows = try #require(rawPayload["rows"] as? [[String: Any]])
             let rawRow = try #require(rawRows.first)
             #expect(rawRow["costUsd"] is NSNull)
+            let rawEffortRows = try #require(rawPayload["effortRows"] as? [[String: Any]])
+            #expect(rawEffortRows.first?["agent"] as? String == "claude")
+            #expect(rawPayload["effortSnapshotComplete"] as? Bool == true)
 
             let payload = try JSONDecoder().decode(BlogUsageIngestPayload.self, from: body)
             #expect(payload.rows == [row])
+            #expect(payload.effortRows == [effortRow])
+            #expect(payload.effortSnapshotComplete)
             return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
         }
 
-        try await client.post(rows: [row], endpoint: URL(string: "https://example.com/api/usage/ingest")!, token: "test-token")
+        try await client.post(
+            rows: [row],
+            effortRows: [effortRow],
+            effortSnapshotComplete: true,
+            endpoint: URL(string: "https://example.com/api/usage/ingest")!,
+            token: "test-token"
+        )
     }
 
     @Test func syncClientThrowsUnauthorizedOnAuthFailure() async throws {
@@ -316,7 +419,13 @@ struct BlogUsageSyncTests {
         }
 
         await #expect(throws: BlogUsageSyncError.self) {
-            try await client.post(rows: [Self.minimalRow()], endpoint: URL(string: "https://example.com")!, token: "bad-token")
+            try await client.post(
+                rows: [Self.minimalRow()],
+                effortRows: [],
+                effortSnapshotComplete: true,
+                endpoint: URL(string: "https://example.com")!,
+                token: "bad-token"
+            )
         }
     }
 
@@ -384,9 +493,24 @@ struct BlogUsageSyncTests {
         try FileManager.default.createDirectory(at: claudeDirectory, withIntermediateDirectories: true)
         let claudeLog = claudeDirectory.appendingPathComponent("usage.jsonl")
         try [
-            Self.claudeLine(id: "shared", inputTokens: 10),
-            Self.claudeLine(id: "shared", inputTokens: 999),
-            Self.claudeLine(id: "unique", inputTokens: 20)
+            Self.claudeLine(
+                id: "shared",
+                inputTokens: 10,
+                sessionID: "claude-session",
+                effort: "high"
+            ),
+            Self.claudeLine(
+                id: "shared",
+                inputTokens: 999,
+                sessionID: "claude-session",
+                effort: "high"
+            ),
+            Self.claudeLine(
+                id: "unique",
+                inputTokens: 20,
+                sessionID: "claude-session",
+                effort: "low"
+            )
         ].joined(separator: "\n").appending("\n")
             .write(to: claudeLog, atomically: true, encoding: .utf8)
 
@@ -394,7 +518,7 @@ struct BlogUsageSyncTests {
         try FileManager.default.createDirectory(at: codexDirectory, withIntermediateDirectories: true)
         let codexLog = codexDirectory.appendingPathComponent("session.jsonl")
         try [
-            Self.codexModelLine(model: "gpt-5"),
+            Self.codexModelLine(model: "gpt-5", effort: "xhigh"),
             Self.codexUsageLine(id: "same-id", inputTokens: 100),
             Self.codexUsageLine(id: "same-id", inputTokens: 200)
         ].joined(separator: "\n").appending("\n")
@@ -409,7 +533,22 @@ struct BlogUsageSyncTests {
             homeDirectory: home,
             environment: ["XDG_DATA_HOME": dataHome.path]
         )
-        let expected = BlogUsageAggregator().aggregate(try parser.parseAllSources())
+        let events = try parser.parseAllSources()
+        let expected = BlogUsageAggregator().aggregate(events)
+        let effortSamples = events.compactMap { event -> EffortUsageSample? in
+            guard let provider = Provider(rawValue: event.agent),
+                  provider == .claude || provider == .codex else {
+                return nil
+            }
+            return EffortUsageSample(
+                provider: provider,
+                sessionID: event.sessionID,
+                effortLevel: event.effortLevel,
+                timestamp: event.timestamp,
+                isSubagentSession: event.isSubagentSession
+            )
+        }
+        let expectedEffort = BlogUsageEffortAggregator.aggregate(effortSamples)
         let indexer = BlogUsageSourceIndexer(
             parser: parser,
             databaseURL: home.appendingPathComponent("index.sqlite")
@@ -419,6 +558,67 @@ struct BlogUsageSyncTests {
 
         #expect(!result.isBackfillInProgress)
         #expect(try await indexer.rows() == expected)
+        #expect(try await indexer.effortRows() == expectedEffort)
+    }
+
+    @Test func indexerPreservesCodexEffortAcrossBudgetedResume() async throws {
+        let home = try Self.temporaryDirectory()
+        let directory = home.appendingPathComponent(".codex/sessions/2026/06", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let context = Self.codexModelLine(model: "gpt-5", effort: " XHIGH ")
+        let usage = Self.codexUsageLine(id: "usage", inputTokens: 100)
+        try "\(context)\n\(usage)\n".write(
+            to: directory.appendingPathComponent("rollout-session.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let indexer = BlogUsageSourceIndexer(
+            parser: BlogUsageSourceParser(homeDirectory: home, environment: [:]),
+            databaseURL: home.appendingPathComponent("index.sqlite")
+        )
+
+        let first = try await indexer.index(maximumBytes: Data("\(context)\n".utf8).count)
+        #expect(first.recordsProcessed == 1)
+        #expect(try await indexer.rows().isEmpty)
+
+        _ = try await indexer.index(maximumBytes: 1_024 * 1_024)
+        let rows = try await indexer.effortRows()
+        let summary = try #require(rows.first { $0.agent == "codex" && $0.date == "2026-06-02" })
+
+        #expect(summary.levels == [EffortLevelCount(level: .xhigh, sessionCount: 1)])
+        #expect(summary.classifiedSessionCount == 1)
+    }
+
+    @Test func indexerUsesLatestCodexCheckpointEffortAndAdvancesRevision() async throws {
+        let home = try Self.temporaryDirectory()
+        let directory = home.appendingPathComponent(".codex/sessions/2026/06", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let log = directory.appendingPathComponent("rollout-session.jsonl")
+        try [
+            Self.codexModelLine(model: "gpt-5", effort: "high"),
+            Self.codexUsageLine(id: "usage", inputTokens: 100)
+        ].joined(separator: "\n").appending("\n")
+            .write(to: log, atomically: true, encoding: .utf8)
+        let indexer = BlogUsageSourceIndexer(
+            parser: BlogUsageSourceParser(homeDirectory: home, environment: [:]),
+            databaseURL: home.appendingPathComponent("index.sqlite")
+        )
+
+        _ = try await indexer.index(maximumBytes: 1_024 * 1_024)
+        let initialRevision = try await indexer.revision()
+        try Self.append(
+            Self.codexModelLine(model: "gpt-5", effort: "ultra").appending("\n"),
+            to: log
+        )
+
+        let result = try await indexer.index(maximumBytes: 1_024 * 1_024)
+        let rows = try await indexer.effortRows()
+        let summary = try #require(rows.first { $0.agent == "codex" && $0.date == "2026-06-02" })
+
+        #expect(result.changedRecords == 0)
+        #expect(try await indexer.revision() > initialRevision)
+        #expect(summary.levels == [EffortLevelCount(level: .ultra, sessionCount: 1)])
+        #expect(summary.classifiedSessionCount == 1)
     }
 
     @Test func indexerBoundsOversizedRecordsResumesAndSkipsWarmPayloadReads() async throws {
@@ -666,6 +866,26 @@ struct BlogUsageSyncTests {
         #expect(try store.revision() == 0)
     }
 
+    @Test func versionOneCacheIsRebuiltForEffortMetadata() throws {
+        let root = try Self.temporaryDirectory()
+        let databaseURL = root.appendingPathComponent("index.sqlite")
+        var database: OpaquePointer?
+        guard sqlite3_open(databaseURL.path, &database) == SQLITE_OK, let database else {
+            throw BlogUsageTestError.sqliteOpenFailed
+        }
+        guard sqlite3_exec(database, "CREATE TABLE legacy (value TEXT)", nil, nil, nil) == SQLITE_OK,
+              sqlite3_exec(database, "PRAGMA user_version = 1", nil, nil, nil) == SQLITE_OK else {
+            sqlite3_close(database)
+            throw BlogUsageTestError.sqliteExecFailed
+        }
+        sqlite3_close(database)
+
+        let store = try BlogUsageIndexStore(databaseURL: databaseURL, timeZoneIdentifier: "UTC")
+
+        #expect(try store.recordCount() == 0)
+        #expect(try store.revision() == 0)
+    }
+
     @Test func persistenceFailureDoesNotAdvanceAFileCheckpoint() async throws {
         let home = try Self.temporaryDirectory()
         let projectDirectory = home.appendingPathComponent(".claude/projects/project-a", isDirectory: true)
@@ -752,6 +972,37 @@ struct BlogUsageSyncTests {
         #expect(await service.syncNow().state == .success)
         #expect(await indexer.rowsCallCount == 3)
         #expect(await posting.callCount == 3)
+    }
+
+    @Test func servicePublishesACompleteEffortSnapshotAfterPartialBackfill() async throws {
+        let defaults = try #require(UserDefaults(suiteName: "BlogUsageSyncTests-\(UUID().uuidString)"))
+        let indexer = ControlledBlogUsageIndexer(
+            revision: 1,
+            rows: [Self.minimalRow()],
+            remainingSources: [1, 0, 0]
+        )
+        let posting = CountingPosting()
+        let keychainAccount = "BlogUsageSyncTests-\(UUID().uuidString)"
+        let service = BlogUsageSyncService(
+            indexer: indexer,
+            client: posting,
+            defaults: defaults,
+            keychainAccount: keychainAccount,
+            oauthProvider: nil
+        )
+        defer { KeychainHelper.deleteString(account: keychainAccount) }
+        await service.setEnabled(true)
+        await service.setEndpointURLString("https://example.com/api/usage/ingest")
+        await service.setToken("test-token")
+
+        #expect(await service.syncNow().state == .success)
+        #expect(await posting.callCount == 1)
+        #expect(await posting.effortSnapshotCompleteness == [false])
+        #expect(await service.syncNow().state == .success)
+        #expect(await posting.callCount == 2)
+        #expect(await posting.effortSnapshotCompleteness == [false, true])
+        #expect(await service.syncNow().state == .success)
+        #expect(await posting.callCount == 2)
     }
 
     @Test func concurrentSyncRequestsShareOneIndexingTask() async throws {
@@ -854,15 +1105,26 @@ struct BlogUsageSyncTests {
         )
     }
 
-    private static func claudeLine(id: String, inputTokens: Int, padding: String = "") -> String {
+    private static func claudeLine(
+        id: String,
+        inputTokens: Int,
+        padding: String = "",
+        sessionID: String? = nil,
+        effort: String? = nil
+    ) -> String {
         let paddingField = padding.isEmpty ? "" : ",\"padding\":\"\(padding)\""
+        let sessionField = sessionID.map { ",\"sessionId\":\"\($0)\"" } ?? ""
+        let effortField = effort.map { ",\"effort\":\"\($0)\"" } ?? ""
         return """
-        {"type":"assistant","timestamp":"2026-06-02T10:00:00Z","requestId":"req-\(id)"\(paddingField),"message":{"id":"\(id)","model":"claude-sonnet-4-5","usage":{"input_tokens":\(inputTokens),"output_tokens":2,"cache_read_input_tokens":3,"cache_creation_input_tokens":4}}}
+        {"type":"assistant","timestamp":"2026-06-02T10:00:00Z","requestId":"req-\(id)"\(paddingField)\(sessionField)\(effortField),"message":{"id":"\(id)","model":"claude-sonnet-4-5","usage":{"input_tokens":\(inputTokens),"output_tokens":2,"cache_read_input_tokens":3,"cache_creation_input_tokens":4}}}
         """
     }
 
-    private static func codexModelLine(model: String) -> String {
-        #"{"timestamp":"2026-06-02T10:00:00Z","payload":{"model":"\#(model)"}}"#
+    private static func codexModelLine(model: String, effort: String? = nil) -> String {
+        if let effort {
+            return #"{"timestamp":"2026-06-02T10:00:00Z","payload":{"model":"\#(model)","effort":"\#(effort)"}}"#
+        }
+        return #"{"timestamp":"2026-06-02T10:00:00Z","payload":{"model":"\#(model)"}}"#
     }
 
     private static func codexUsageLine(id: String, inputTokens: Int) -> String {
@@ -1008,14 +1270,22 @@ private final class BlogUsageURLProtocol: URLProtocol {
 
 private actor CountingPosting: BlogUsageSyncPosting {
     private(set) var callCount = 0
+    private(set) var effortSnapshotCompleteness: [Bool] = []
     private var error: Error?
 
     func setError(_ error: Error?) {
         self.error = error
     }
 
-    func post(rows: [BlogUsageIngestRow], endpoint: URL, token: String) async throws {
+    func post(
+        rows: [BlogUsageIngestRow],
+        effortRows: [BlogUsageEffortIngestRow],
+        effortSnapshotComplete: Bool,
+        endpoint: URL,
+        token: String
+    ) async throws {
         callCount += 1
+        effortSnapshotCompleteness.append(effortSnapshotComplete)
         if let error {
             throw error
         }
@@ -1026,6 +1296,7 @@ private actor ControlledBlogUsageIndexer: BlogUsageIndexing {
     private let currentRevision: Int64
     private let cachedRows: [BlogUsageIngestRow]
     private let delayNanoseconds: UInt64
+    private let remainingSources: [Int]
     private var uploadedRevisions: [String: Int64] = [:]
     private(set) var indexCallCount = 0
     private(set) var rowsCallCount = 0
@@ -1034,11 +1305,13 @@ private actor ControlledBlogUsageIndexer: BlogUsageIndexing {
     init(
         revision: Int64,
         rows: [BlogUsageIngestRow],
-        delayNanoseconds: UInt64 = 0
+        delayNanoseconds: UInt64 = 0,
+        remainingSources: [Int] = [0]
     ) {
         self.currentRevision = revision
         self.cachedRows = rows
         self.delayNanoseconds = delayNanoseconds
+        self.remainingSources = remainingSources
     }
 
     func index(maximumBytes: Int) async throws -> BlogUsageIndexResult {
@@ -1055,7 +1328,7 @@ private actor ControlledBlogUsageIndexer: BlogUsageIndexing {
             changedRecords: 0,
             cacheRows: cachedRows.count,
             maximumBufferedBytes: 0,
-            remainingSources: 0
+            remainingSources: remainingSources[min(indexCallCount - 1, remainingSources.count - 1)]
         )
     }
 
@@ -1063,6 +1336,8 @@ private actor ControlledBlogUsageIndexer: BlogUsageIndexing {
         rowsCallCount += 1
         return cachedRows
     }
+
+    func effortRows() async throws -> [BlogUsageEffortIngestRow] { [] }
 
     func revision() async throws -> Int64 {
         currentRevision
@@ -1106,6 +1381,7 @@ private final class FailingBlogUsageIndexStore: BlogUsageIndexStoring, @unchecke
     func deleteRecord(source: BlogUsageIndexedSource, container: String, recordKey: String) throws -> Bool { false }
     func deleteRecords(source: BlogUsageIndexedSource, container: String) throws -> Bool { false }
     func aggregateRows() throws -> [BlogUsageIngestRow] { [] }
+    func effortUsageSamples() throws -> [EffortUsageSample] { [] }
     func recordCount() throws -> Int { 0 }
     func revision() throws -> Int64 { 0 }
     func advanceRevision() throws -> Int64 { 0 }


### PR DESCRIPTION
## Summary

- Track session IDs, effort levels, and subagent metadata for Claude and Codex usage records
- Persist effort metadata in the SQLite index with schema versioning
- Aggregate effort by session and daily provider buckets
- Include effort aggregates in sync payloads with support for partial backfills

## Testing

- Updated blog usage sync tests
- Not run (not requested)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tartinerlabs/codesmith/AgentUsage/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788182254&installation_model_id=427837&pr_number=96&repository=tartinerlabs%2FAgentUsage&return_to=https%3A%2F%2Fgithub.com%2Ftartinerlabs%2FAgentUsage%2Fpull%2F96&signature=e0720120097e99ee53d92607fcab71d14dbb22f295e3dec148618d6a83bd157a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->