### PR TITLE
Support multi-provider widget configurations and timelines

### DIFF
--- a/AgentUsage/Shared/Protocols/WidgetDataServiceProtocol.swift
+++ b/AgentUsage/Shared/Protocols/WidgetDataServiceProtocol.swift
@@ -10,13 +10,11 @@ import AgentUsageKit
 /// Protocol for managing widget data via App Groups
 /// Enables dependency injection and testing with mock implementations
 protocol WidgetDataServiceProtocol: Actor {
-    /// Save snapshot to shared UserDefaults and reload widget timelines
-    /// - Parameter snapshot: Usage snapshot to cache for widgets
-    func save(_ snapshot: UsageSnapshot) async
+    /// Save all enabled provider snapshots and reload widget timelines.
+    func save(_ snapshots: [ProviderUsageSnapshot]) async
 
-    /// Load snapshot from shared UserDefaults
-    /// - Returns: Cached usage snapshot, or nil if not available
-    nonisolated func load() -> UsageSnapshot?
+    /// Load cached provider snapshots from shared UserDefaults.
+    nonisolated func load() -> [ProviderUsageSnapshot]
 
     /// Clear cached data and reload widget timelines
     func clear() async

--- a/AgentUsage/Shared/Services/WidgetDataManager.swift
+++ b/AgentUsage/Shared/Services/WidgetDataManager.swift
@@ -19,19 +19,19 @@ actor WidgetDataManager: WidgetDataServiceProtocol {
 
     private init() {}
 
-    /// Save snapshot to shared storage and reload widget timelines
-    func save(_ snapshot: UsageSnapshot) {
-        if WidgetDataStorage.shared.save(snapshot) {
-            Logger.widget.debug("Saved snapshot to App Groups")
+    /// Save all provider snapshots to shared storage and reload widget timelines.
+    func save(_ snapshots: [ProviderUsageSnapshot]) {
+        if WidgetDataStorage.shared.save(snapshots) {
+            Logger.widget.debug("Saved provider snapshots to App Groups")
             WidgetCenter.shared.reloadAllTimelines()
         } else {
-            Logger.widget.error("Failed to save snapshot")
+            Logger.widget.error("Failed to save provider snapshots")
         }
     }
 
-    /// Load snapshot from shared storage
-    nonisolated func load() -> UsageSnapshot? {
-        WidgetDataStorage.shared.load()
+    /// Load provider snapshots from shared storage.
+    nonisolated func load() -> [ProviderUsageSnapshot] {
+        WidgetDataStorage.shared.loadProviderSnapshots()
     }
 
     /// Clear cached data and reload widget timelines

--- a/AgentUsage/ViewModels/UsageViewModel.swift
+++ b/AgentUsage/ViewModels/UsageViewModel.swift
@@ -816,10 +816,13 @@ extension UsageViewModel {
             // Check for threshold crossings before platform-specific follow-up work.
             await checkUsageNotifications(oldSnapshot: oldSnapshot, newSnapshot: newSnapshot)
 
-            // Cache snapshot for widgets and update Live Activity (iOS only)
+            // Cache every provider for widgets and update Live Activity (iOS only).
             #if os(iOS)
-            if let snapshot {
-                await WidgetDataManager.shared.save(snapshot)
+            let widgetSnapshots = availableProviderSnapshots
+            if widgetSnapshots.isEmpty {
+                await WidgetDataManager.shared.clear()
+            } else {
+                await WidgetDataManager.shared.save(widgetSnapshots)
             }
             await liveActivityManager.refresh(from: availableProviderSnapshots)
             #endif
@@ -952,10 +955,11 @@ extension UsageViewModel {
             fetchedAt: synced.fetchedAt
         )
 
-        if let snapshot {
-            await WidgetDataManager.shared.save(snapshot)
-        } else {
+        let widgetSnapshots = availableProviderSnapshots
+        if widgetSnapshots.isEmpty {
             await WidgetDataManager.shared.clear()
+        } else {
+            await WidgetDataManager.shared.save(widgetSnapshots)
         }
         await liveActivityManager.refresh(from: availableProviderSnapshots)
     }

--- a/AgentUsageKit/Sources/AgentUsageKit/Models/UsageActivitySelection.swift
+++ b/AgentUsageKit/Sources/AgentUsageKit/Models/UsageActivitySelection.swift
@@ -2,10 +2,10 @@
 //  UsageActivitySelection.swift
 //  AgentUsageKit
 //
-//  Stable provider/window identity for Live Activities.
+//  Stable provider/window identity for widgets and Live Activities.
 //
 
-/// Identifies the exact provider rate window tracked by a Live Activity.
+/// Identifies the exact provider rate window tracked by a widget or Live Activity.
 ///
 /// The provider is part of the identity because different providers may use the
 /// same window identifier (for example, `session`).

--- a/AgentUsageKit/Sources/AgentUsageKit/Services/WidgetDataStorage.swift
+++ b/AgentUsageKit/Sources/AgentUsageKit/Services/WidgetDataStorage.swift
@@ -3,58 +3,183 @@
 //  AgentUsageKit
 //
 //  Shared widget data storage for cross-process communication via App Groups
-//  This is a read-only interface used by both the main app and widget extension
 //
 
 import Foundation
 
-/// Shared widget data storage for reading cached snapshots
-/// Used by both the main iOS app and widget extension via App Groups
-public final class WidgetDataStorage: Sendable {
-    /// Shared instance for accessing widget data
-    public static let shared = WidgetDataStorage()
+/// Versioned provider-neutral data handed to WidgetKit.
+///
+/// `UsageSnapshot` predates multi-provider support and has fixed Claude fields.
+/// Keeping the widget payload separate lets WidgetKit render provider-defined
+/// windows (including Cursor's dynamic identifiers) without changing that legacy
+/// API model.
+public struct WidgetUsagePayload: Codable, Sendable {
+    public static let currentSchemaVersion = 1
 
-    /// App Group suite name for shared UserDefaults
-    public static let suiteName = "group.com.tartinerlabs.AgentUsage"
+    public let schemaVersion: Int
+    public let providerSnapshots: [ProviderUsageSnapshot]
 
-    /// Key for cached usage snapshot
-    public static let snapshotKey = "cachedUsageSnapshot"
-
-    private init() {}
-
-    /// Load snapshot from shared UserDefaults
-    /// - Returns: Cached usage snapshot, or nil if not available
-    public func load() -> UsageSnapshot? {
-        guard let defaults = UserDefaults(suiteName: Self.suiteName),
-              let data = defaults.data(forKey: Self.snapshotKey) else {
-            return nil
-        }
-
-        return try? JSONDecoder().decode(UsageSnapshot.self, from: data)
+    public init(
+        snapshot: UsageSnapshot? = nil,
+        providerSnapshots: [ProviderUsageSnapshot],
+        schemaVersion: Int = Self.currentSchemaVersion
+    ) {
+        self.schemaVersion = schemaVersion
+        self.providerSnapshots = Self.normalized(
+            snapshot: snapshot,
+            providerSnapshots: providerSnapshots
+        )
     }
 
-    /// Save snapshot to shared UserDefaults
-    /// Note: This does not trigger widget timeline refresh - caller should handle that
-    /// - Parameter snapshot: Usage snapshot to cache
-    /// - Returns: True if save succeeded
-    @discardableResult
-    public func save(_ snapshot: UsageSnapshot) -> Bool {
-        guard let defaults = UserDefaults(suiteName: Self.suiteName) else {
-            return false
+    public func snapshot(for provider: Provider) -> ProviderUsageSnapshot? {
+        providerSnapshots.first { $0.provider == provider }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case providerSnapshots
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion)
+            ?? Self.currentSchemaVersion
+        let snapshots = try container.decode([ProviderUsageSnapshot].self, forKey: .providerSnapshots)
+        providerSnapshots = Self.normalized(snapshot: nil, providerSnapshots: snapshots)
+    }
+
+    private static func normalized(
+        snapshot: UsageSnapshot?,
+        providerSnapshots: [ProviderUsageSnapshot]
+    ) -> [ProviderUsageSnapshot] {
+        // Modern provider snapshots are authoritative. The fixed Claude payload is
+        // bridged only for records written by older app versions.
+        var snapshotsByProvider: [Provider: ProviderUsageSnapshot] = [:]
+        for providerSnapshot in providerSnapshots {
+            snapshotsByProvider[providerSnapshot.provider] = providerSnapshot
+        }
+        if snapshotsByProvider[.claude] == nil, let snapshot {
+            snapshotsByProvider[.claude] = ProviderUsageSnapshot(claude: snapshot)
         }
 
+        return Provider.allCases.compactMap { snapshotsByProvider[$0] }
+    }
+}
+
+/// Shared App Group storage used by the iOS app and widget extension.
+public final class WidgetDataStorage: Sendable {
+    public static let shared = WidgetDataStorage()
+
+    public static let suiteName = "group.com.tartinerlabs.AgentUsage"
+
+    /// Legacy Claude-only key. Retained so already-installed widgets migrate.
+    public static let snapshotKey = "cachedUsageSnapshot"
+
+    /// Current provider-neutral payload key.
+    public static let payloadKey = "cachedWidgetUsagePayload"
+
+    private let suiteName: String
+
+    /// A custom suite is accepted so persistence and migration can be tested
+    /// without touching the real App Group.
+    public init(suiteName: String = WidgetDataStorage.suiteName) {
+        self.suiteName = suiteName
+    }
+
+    /// Load the current payload, falling back to the legacy Claude snapshot.
+    public func loadPayload() -> WidgetUsagePayload? {
+        guard let defaults = UserDefaults(suiteName: suiteName) else { return nil }
+
+        if let data = defaults.data(forKey: Self.payloadKey),
+           let payload = try? JSONDecoder().decode(WidgetUsagePayload.self, from: data) {
+            return payload
+        }
+
+        guard let snapshot = loadLegacySnapshot(from: defaults) else { return nil }
+        return WidgetUsagePayload(snapshot: snapshot, providerSnapshots: [])
+    }
+
+    /// Provider snapshots available to WidgetKit, in canonical provider order.
+    public func loadProviderSnapshots() -> [ProviderUsageSnapshot] {
+        loadPayload()?.providerSnapshots ?? []
+    }
+
+    /// Legacy compatibility accessor. New widget code should use `loadPayload()`.
+    public func load() -> UsageSnapshot? {
+        guard let defaults = UserDefaults(suiteName: suiteName) else { return nil }
+        if let snapshot = loadLegacySnapshot(from: defaults) {
+            return snapshot
+        }
+        guard let claude = loadPayload()?.snapshot(for: .claude) else { return nil }
+        return Self.legacySnapshot(from: claude)
+    }
+
+    /// Save a provider-neutral payload. The legacy key is dual-written when a
+    /// complete Claude snapshot is present and removed for provider-only updates,
+    /// preventing stale Claude data from surviving a newer Codex/Cursor refresh.
+    @discardableResult
+    public func save(_ payload: WidgetUsagePayload) -> Bool {
+        guard let defaults = UserDefaults(suiteName: suiteName) else { return false }
+
         do {
-            let data = try JSONEncoder().encode(snapshot)
-            defaults.set(data, forKey: Self.snapshotKey)
+            let payloadData = try JSONEncoder().encode(payload)
+            let legacyData = try payload.snapshot(for: .claude)
+                .flatMap(Self.legacySnapshot(from:))
+                .map { try JSONEncoder().encode($0) }
+
+            defaults.set(payloadData, forKey: Self.payloadKey)
+            if let legacyData {
+                defaults.set(legacyData, forKey: Self.snapshotKey)
+            } else {
+                defaults.removeObject(forKey: Self.snapshotKey)
+            }
             return true
         } catch {
             return false
         }
     }
 
-    /// Clear cached data
+    @discardableResult
+    public func save(_ providerSnapshots: [ProviderUsageSnapshot]) -> Bool {
+        save(WidgetUsagePayload(providerSnapshots: providerSnapshots))
+    }
+
+    /// Legacy compatibility writer. It also seeds the provider-neutral payload.
+    @discardableResult
+    public func save(_ snapshot: UsageSnapshot) -> Bool {
+        save(WidgetUsagePayload(snapshot: snapshot, providerSnapshots: []))
+    }
+
     public func clear() {
-        guard let defaults = UserDefaults(suiteName: Self.suiteName) else { return }
+        guard let defaults = UserDefaults(suiteName: suiteName) else { return }
+        defaults.removeObject(forKey: Self.payloadKey)
         defaults.removeObject(forKey: Self.snapshotKey)
+    }
+
+    private func loadLegacySnapshot(from defaults: UserDefaults) -> UsageSnapshot? {
+        guard let data = defaults.data(forKey: Self.snapshotKey) else { return nil }
+        return try? JSONDecoder().decode(UsageSnapshot.self, from: data)
+    }
+
+    private static func legacySnapshot(from snapshot: ProviderUsageSnapshot) -> UsageSnapshot? {
+        guard snapshot.provider == .claude,
+              let session = snapshot.windows.first(where: { $0.windowID.rawValue == UsageWindowType.session.rawValue }),
+              let opus = snapshot.windows.first(where: { $0.windowID.rawValue == UsageWindowType.opus.rawValue }) else {
+            return nil
+        }
+
+        func window(_ type: UsageWindowType) -> UsageWindow? {
+            snapshot.windows.first { $0.windowID.rawValue == type.rawValue }
+        }
+
+        return UsageSnapshot(
+            session: session,
+            opus: opus,
+            sonnet: window(.sonnet),
+            design: window(.design),
+            fable: window(.fable),
+            extraUsage: snapshot.extraUsage,
+            fetchedAt: snapshot.fetchedAt
+        )
     }
 }

--- a/AgentUsageKit/Tests/AgentUsageKitTests/WidgetDataStorageTests.swift
+++ b/AgentUsageKit/Tests/AgentUsageKitTests/WidgetDataStorageTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import Testing
+@testable import AgentUsageKit
+
+@Suite("WidgetDataStorage")
+struct WidgetDataStorageTests {
+    @Test func providerOnlyPayloadRoundTripsAndRemovesStaleClaudeCache() throws {
+        let fixture = try StorageFixture()
+        defer { fixture.clear() }
+        let legacy = Self.claudeSnapshot()
+        #expect(fixture.storage.save(legacy))
+        #expect(fixture.storage.load() != nil)
+
+        let codex = Self.providerSnapshot(provider: .codex, windowType: .codexFiveHour)
+        #expect(fixture.storage.save([codex]))
+
+        let loaded = fixture.storage.loadProviderSnapshots()
+        #expect(loaded.map(\.provider) == [.codex])
+        #expect(fixture.storage.load() == nil)
+        #expect(fixture.defaults.data(forKey: WidgetDataStorage.snapshotKey) == nil)
+    }
+
+    @Test func multipleProvidersAndCustomWindowMetadataRoundTrip() throws {
+        let fixture = try StorageFixture()
+        defer { fixture.clear() }
+        let reset = Date().addingTimeInterval(31 * 24 * 3_600)
+        let cursor = ProviderUsageSnapshot(
+            provider: .cursor,
+            windows: [
+                UsageWindow(
+                    utilization: 37.5,
+                    resetsAt: reset,
+                    windowID: "cursor.total",
+                    displayName: "Total usage",
+                    totalDuration: 31 * 24 * 3_600,
+                    scope: UsageWindowScope(model: "auto")
+                ),
+            ],
+            extraUsage: ExtraUsageCost(used: 12, limit: 50, currencyCode: "USD"),
+            fetchedAt: Date()
+        )
+        let claude = ProviderUsageSnapshot(claude: Self.claudeSnapshot())
+        let codex = Self.providerSnapshot(provider: .codex, windowType: .codexWeekly)
+
+        // Storage normalizes to Provider.allCases order, independent of input order.
+        #expect(fixture.storage.save([cursor, codex, claude]))
+        let loaded = fixture.storage.loadProviderSnapshots()
+
+        #expect(loaded.map(\.provider) == [.claude, .codex, .cursor])
+        let loadedCursor = try #require(loaded.first { $0.provider == .cursor })
+        let window = try #require(loadedCursor.windows.first)
+        #expect(window.windowID.rawValue == "cursor.total")
+        #expect(window.displayName == "Total usage")
+        #expect(window.totalDuration == 31 * 24 * 3_600)
+        #expect(window.scope?.model == "auto")
+        #expect(loadedCursor.extraUsage?.used == 12)
+    }
+
+    @Test func legacyUsageSnapshotLoadsAsClaudeProvider() throws {
+        let fixture = try StorageFixture()
+        defer { fixture.clear() }
+        let legacy = Self.claudeSnapshot()
+        fixture.defaults.set(
+            try JSONEncoder().encode(legacy),
+            forKey: WidgetDataStorage.snapshotKey
+        )
+
+        let payload = try #require(fixture.storage.loadPayload())
+        #expect(payload.providerSnapshots.map(\.provider) == [.claude])
+        #expect(payload.providerSnapshots.first?.windows.map(\.windowID.rawValue) == ["session", "opus"])
+    }
+
+    @Test func modernClaudeSnapshotWinsOverLegacyBridge() throws {
+        let legacy = Self.claudeSnapshot(sessionUtilization: 10)
+        let modern = ProviderUsageSnapshot(
+            provider: .claude,
+            windows: [
+                UsageWindow(
+                    utilization: 88,
+                    resetsAt: Date().addingTimeInterval(3_600),
+                    windowType: .session
+                ),
+            ],
+            fetchedAt: Date()
+        )
+
+        let payload = WidgetUsagePayload(snapshot: legacy, providerSnapshots: [modern])
+
+        #expect(payload.providerSnapshots.count == 1)
+        #expect(payload.snapshot(for: .claude)?.windows.first?.utilization == 88)
+    }
+
+    @Test func corruptModernPayloadFallsBackToLegacySnapshot() throws {
+        let fixture = try StorageFixture()
+        defer { fixture.clear() }
+        fixture.defaults.set(Data("not-json".utf8), forKey: WidgetDataStorage.payloadKey)
+        fixture.defaults.set(
+            try JSONEncoder().encode(Self.claudeSnapshot()),
+            forKey: WidgetDataStorage.snapshotKey
+        )
+
+        #expect(fixture.storage.loadProviderSnapshots().map(\.provider) == [.claude])
+    }
+
+    @Test func clearRemovesModernAndLegacyPayloads() throws {
+        let fixture = try StorageFixture()
+        defer { fixture.clear() }
+        #expect(fixture.storage.save([Self.providerSnapshot(provider: .codex, windowType: .codexFiveHour)]))
+        fixture.defaults.set(Data([0x1]), forKey: WidgetDataStorage.snapshotKey)
+
+        fixture.storage.clear()
+
+        #expect(fixture.defaults.data(forKey: WidgetDataStorage.payloadKey) == nil)
+        #expect(fixture.defaults.data(forKey: WidgetDataStorage.snapshotKey) == nil)
+        #expect(fixture.storage.loadPayload() == nil)
+    }
+
+    private static func claudeSnapshot(sessionUtilization: Double = 20) -> UsageSnapshot {
+        let now = Date()
+        return UsageSnapshot(
+            session: UsageWindow(
+                utilization: sessionUtilization,
+                resetsAt: now.addingTimeInterval(3_600),
+                windowType: .session
+            ),
+            opus: UsageWindow(
+                utilization: 30,
+                resetsAt: now.addingTimeInterval(7_200),
+                windowType: .opus
+            ),
+            sonnet: nil,
+            fetchedAt: now
+        )
+    }
+
+    private static func providerSnapshot(
+        provider: Provider,
+        windowType: UsageWindowType
+    ) -> ProviderUsageSnapshot {
+        ProviderUsageSnapshot(
+            provider: provider,
+            windows: [
+                UsageWindow(
+                    utilization: 42,
+                    resetsAt: Date().addingTimeInterval(3_600),
+                    windowType: windowType
+                ),
+            ],
+            fetchedAt: Date()
+        )
+    }
+}
+
+private struct StorageFixture {
+    let suiteName: String
+    let defaults: UserDefaults
+    let storage: WidgetDataStorage
+
+    init() throws {
+        suiteName = "WidgetDataStorageTests.\(UUID().uuidString)"
+        defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        storage = WidgetDataStorage(suiteName: suiteName)
+    }
+
+    func clear() {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+}

--- a/AgentUsageWidgets/AgentUsageWidgets.swift
+++ b/AgentUsageWidgets/AgentUsageWidgets.swift
@@ -13,21 +13,25 @@ struct AgentUsageWidgets: Widget {
     let kind: String = "AgentUsageWidgets"
 
     var body: some WidgetConfiguration {
-        AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
+        AppIntentConfiguration(
+            kind: kind,
+            intent: ConfigurationAppIntent.self,
+            provider: HomeScreenTimelineProvider()
+        ) { entry in
             AgentUsageWidgetsEntryView(entry: entry)
                 .containerBackground(for: .widget) {
-                    WidgetProviderBackground(provider: WidgetDesign.provider)
+                    WidgetProviderBackground(provider: entry.provider)
                 }
         }
-        .configurationDisplayName("Claude Usage")
-        .description("Track Claude usage windows at a glance.")
+        .configurationDisplayName("Agent Usage")
+        .description("Track an AI coding provider's usage windows at a glance.")
         .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
     }
 }
 
 struct AgentUsageWidgetsEntryView: View {
     @Environment(\.widgetFamily) var family
-    var entry: Provider.Entry
+    var entry: HomeScreenTimelineProvider.Entry
 
     var body: some View {
         switch family {
@@ -49,12 +53,16 @@ struct AgentUsageLockScreenWidget: Widget {
     let kind: String = "AgentUsageLockScreenWidget"
 
     var body: some WidgetConfiguration {
-        AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: LockScreenProvider()) { entry in
+        AppIntentConfiguration(
+            kind: kind,
+            intent: ConfigurationAppIntent.self,
+            provider: LockScreenTimelineProvider()
+        ) { entry in
             LockScreenWidgetView(entry: entry)
                 .containerBackground(.fill.tertiary, for: .widget)
         }
-        .configurationDisplayName("Claude Usage")
-        .description("Check a Claude usage window at a glance.")
+        .configurationDisplayName("Agent Usage")
+        .description("Check a provider usage window at a glance.")
         .supportedFamilies([.accessoryCircular, .accessoryRectangular, .accessoryInline])
     }
 }

--- a/AgentUsageWidgets/AppIntent.swift
+++ b/AgentUsageWidgets/AppIntent.swift
@@ -3,9 +3,14 @@
 //  AgentUsageWidgets
 //
 
-import WidgetKit
+import AgentUsageKit
 import AppIntents
+import Foundation
+import WidgetKit
 
+/// Legacy Claude configuration values retained so existing widgets keep their
+/// selected window. The parameter is omitted from `parameterSummary`, so new
+/// configuration sheets expose only the provider-neutral entity picker.
 enum MetricType: String, AppEnum {
     case session
     case opus
@@ -20,24 +25,148 @@ enum MetricType: String, AppEnum {
         .opus: DisplayRepresentation(title: "All models (7d)"),
         .sonnet: DisplayRepresentation(title: "Sonnet (7d)"),
         .design: DisplayRepresentation(title: "Claude Design (7d)"),
-        .fable: DisplayRepresentation(title: "Fable (7d)")
+        .fable: DisplayRepresentation(title: "Fable (7d)"),
+    ]
+}
+
+/// A provider/window pair offered in the widget configuration sheet.
+///
+/// The identifier includes the provider because providers may use the same
+/// window ID. The remaining fields let WidgetKit preserve the selection without
+/// reducing dynamic Cursor windows to `UsageWindowType.custom`.
+struct WidgetUsageWindowEntity: AppEntity {
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Usage Window")
+    static var defaultQuery = WidgetUsageWindowQuery()
+
+    let id: String
+    let providerRawValue: String
+    let windowIDRawValue: String
+    let displayName: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: "\(displayName)",
+            subtitle: "\(provider?.displayName ?? "Unknown provider")"
+        )
+    }
+
+    var provider: AgentUsageKit.Provider? {
+        AgentUsageKit.Provider(rawValue: providerRawValue)
+    }
+
+    var selection: UsageActivitySelection? {
+        guard let provider else { return nil }
+        return UsageActivitySelection(
+            provider: provider,
+            windowID: UsageWindowID(rawValue: windowIDRawValue)
+        )
+    }
+
+    init(provider: AgentUsageKit.Provider, window: UsageWindow) {
+        id = Self.identifier(provider: provider, windowID: window.windowID)
+        providerRawValue = provider.rawValue
+        windowIDRawValue = window.windowID.rawValue
+        displayName = window.displayName
+    }
+
+    /// Rebuild enough identity to preserve an existing configuration when its
+    /// provider cache is temporarily absent. The real display name replaces this
+    /// fallback as soon as the next provider snapshot arrives.
+    init?(identifier: String) {
+        guard let separator = identifier.firstIndex(of: "/") else { return nil }
+        let providerValue = String(identifier[..<separator])
+        let windowValue = String(identifier[identifier.index(after: separator)...])
+        guard AgentUsageKit.Provider(rawValue: providerValue) != nil,
+              !windowValue.isEmpty else {
+            return nil
+        }
+
+        id = identifier
+        providerRawValue = providerValue
+        windowIDRawValue = windowValue
+        displayName = UsageWindowType(rawValue: windowValue)?.displayName ?? "Usage"
+    }
+
+    private static func identifier(
+        provider: AgentUsageKit.Provider,
+        windowID: UsageWindowID
+    ) -> String {
+        "\(provider.rawValue)/\(windowID.rawValue)"
+    }
+}
+
+struct WidgetUsageWindowQuery: EntityQuery {
+    /// Only providers currently wired by the app are configurable. OpenCode's
+    /// services remain deliberately disabled even though its model types exist.
+    private static let supportedProviders: Set<AgentUsageKit.Provider> = [
+        .claude,
+        .codex,
+        .cursor,
     ]
 
-    var displayName: String {
-        switch self {
-        case .session: return "Current session"
-        case .opus: return "All models"
-        case .sonnet: return "Sonnet"
-        case .design: return "Claude Design"
-        case .fable: return "Fable"
+    func entities(for identifiers: [WidgetUsageWindowEntity.ID]) async throws -> [WidgetUsageWindowEntity] {
+        let knownEntities = Dictionary(
+            uniqueKeysWithValues: entities(includeExpired: true).map { ($0.id, $0) }
+        )
+        return identifiers.compactMap { identifier in
+            if let known = knownEntities[identifier] { return known }
+            guard let fallback = WidgetUsageWindowEntity(identifier: identifier),
+                  let provider = fallback.provider,
+                  Self.supportedProviders.contains(provider) else {
+                return nil
+            }
+            return fallback
+        }
+    }
+
+    func suggestedEntities() async throws -> [WidgetUsageWindowEntity] {
+        let snapshots = await WidgetTimelineLoader.currentSnapshots()
+        return entities(in: snapshots, includeExpired: false)
+    }
+
+    private func entities(
+        in snapshots: [ProviderUsageSnapshot]? = nil,
+        includeExpired: Bool
+    ) -> [WidgetUsageWindowEntity] {
+        let now = Date()
+        let providerSnapshots = snapshots ?? WidgetDataStorage.shared.loadProviderSnapshots()
+        return providerSnapshots.flatMap {
+            snapshot -> [WidgetUsageWindowEntity] in
+            guard Self.supportedProviders.contains(snapshot.provider) else { return [] }
+            return snapshot.windows
+                .filter { includeExpired || !$0.isExpired(from: now) }
+                .map { WidgetUsageWindowEntity(provider: snapshot.provider, window: $0) }
         }
     }
 }
 
 struct ConfigurationAppIntent: WidgetConfigurationIntent {
-    static var title: LocalizedStringResource = "Select Metric"
-    static var description = IntentDescription("Choose which usage metric to display")
+    static var title: LocalizedStringResource = "Select Usage Window"
+    static var description = IntentDescription(
+        "Choose a provider usage window to display. Larger widgets show the other windows for that provider too."
+    )
 
-    @Parameter(title: "Metric", default: .session)
+    /// Kept under its original property name and raw enum values so WidgetKit can
+    /// decode configurations created by earlier app versions.
+    @Parameter(title: "Legacy Claude Metric", default: .session)
     var metric: MetricType
+
+    /// Optional so a widget can be added before the Mac has published data. The
+    /// stable legacy Claude selection is used until a provider window is chosen.
+    @Parameter(title: "Usage Window")
+    var usageWindow: WidgetUsageWindowEntity?
+
+    static var parameterSummary: some ParameterSummary {
+        Summary {
+            \.$usageWindow
+        }
+    }
+
+    var selection: UsageActivitySelection {
+        usageWindow?.selection
+            ?? UsageActivitySelection(
+                provider: .claude,
+                windowID: UsageWindowID(rawValue: metric.rawValue)
+            )
+    }
 }

--- a/AgentUsageWidgets/PreviewFixtures.swift
+++ b/AgentUsageWidgets/PreviewFixtures.swift
@@ -2,66 +2,104 @@
 //  PreviewFixtures.swift
 //  AgentUsageWidgets
 //
-//  Fabricated snapshots exist here and nowhere else.
-//
-//  This used to live on `UsageSnapshot.placeholder` in AgentUsageKit, where the
-//  timeline provider reached for it whenever CloudKit and the App Group cache
-//  were both empty — so a fresh install rendered invented percentages as if they
-//  were real. Keeping the fixture in the widget target behind `#if DEBUG` means
-//  a release binary contains no sample usage figures at all; the shipping
-//  no-data path is `WidgetNoDataView`.
-//
-//  Everything below is `#if DEBUG` and must stay that way.
+//  Fabricated snapshots exist here and nowhere else. Everything below remains
+//  DEBUG-only so shipping widgets never present sample values as real usage.
 //
 
 #if DEBUG
-import Foundation
 import AgentUsageKit
+import Foundation
 
-extension UsageSnapshot {
-    /// Representative usage for Xcode canvas previews only.
-    static var previewSample: UsageSnapshot {
+extension ProviderUsageSnapshot {
+    static var widgetPreviewSnapshots: [ProviderUsageSnapshot] {
         let now = Date()
-        return UsageSnapshot(
-            session: UsageWindow(
-                utilization: 45,
-                resetsAt: now.addingTimeInterval(2.5 * 60 * 60),
-                windowType: .session
+        return [
+            ProviderUsageSnapshot(
+                provider: .claude,
+                windows: [
+                    UsageWindow(
+                        utilization: 45,
+                        resetsAt: now.addingTimeInterval(2.5 * 60 * 60),
+                        windowType: .session
+                    ),
+                    UsageWindow(
+                        utilization: 32,
+                        resetsAt: now.addingTimeInterval(4 * 24 * 60 * 60),
+                        windowType: .opus
+                    ),
+                    UsageWindow(
+                        utilization: 28,
+                        resetsAt: now.addingTimeInterval(5 * 24 * 60 * 60),
+                        windowType: .sonnet
+                    ),
+                ],
+                planName: "Max",
+                fetchedAt: now
             ),
-            opus: UsageWindow(
-                utilization: 32,
-                resetsAt: now.addingTimeInterval(4 * 24 * 60 * 60),
-                windowType: .opus
+            ProviderUsageSnapshot(
+                provider: .codex,
+                windows: [
+                    UsageWindow(
+                        utilization: 72,
+                        resetsAt: now.addingTimeInterval(90 * 60),
+                        windowType: .codexFiveHour
+                    ),
+                    UsageWindow(
+                        utilization: 38,
+                        resetsAt: now.addingTimeInterval(5 * 24 * 60 * 60),
+                        windowType: .codexWeekly
+                    ),
+                ],
+                planName: "Plus",
+                fetchedAt: now
             ),
-            sonnet: UsageWindow(
-                utilization: 28,
-                resetsAt: now.addingTimeInterval(5 * 24 * 60 * 60),
-                windowType: .sonnet
+            ProviderUsageSnapshot(
+                provider: .cursor,
+                windows: [
+                    UsageWindow(
+                        utilization: 92,
+                        resetsAt: now.addingTimeInterval(12 * 24 * 60 * 60),
+                        windowID: "cursor.monthly.requests",
+                        displayName: "Monthly agent requests",
+                        totalDuration: 30 * 24 * 60 * 60
+                    ),
+                    UsageWindow(
+                        utilization: 24,
+                        resetsAt: now.addingTimeInterval(12 * 24 * 60 * 60),
+                        windowID: "cursor.api.usage",
+                        displayName: "API usage",
+                        totalDuration: 30 * 24 * 60 * 60
+                    ),
+                ],
+                planName: "Pro",
+                fetchedAt: now
             ),
-            design: UsageWindow(
-                utilization: 12,
-                resetsAt: now.addingTimeInterval(5 * 24 * 60 * 60),
-                windowType: .design
-            ),
-            fable: UsageWindow(
-                utilization: 16,
-                resetsAt: now.addingTimeInterval(5 * 24 * 60 * 60),
-                windowType: .fable
-            ),
-            fetchedAt: now
-        )
+        ]
     }
 }
 
 extension WidgetEntry {
-    /// A populated entry for previews.
-    static func preview(metric: MetricType = .session) -> WidgetEntry {
-        WidgetEntry(date: .now, snapshot: .previewSample, metric: metric)
+    static func preview(provider: AgentUsageKit.Provider = .claude) -> WidgetEntry {
+        let snapshots = ProviderUsageSnapshot.widgetPreviewSnapshots
+        let window = snapshots.first(where: { $0.provider == provider })?.windows.first
+        let selection = window.map {
+            UsageActivitySelection(provider: provider, windowID: $0.windowID)
+        }
+        return WidgetEntry(date: .now, snapshots: snapshots, selection: selection)
     }
 
-    /// The empty state as the shipping app produces it — no snapshot at all.
-    static func previewNoData(metric: MetricType = .session) -> WidgetEntry {
-        WidgetEntry(date: .now, snapshot: nil, metric: metric)
+    static func previewNoData(provider: AgentUsageKit.Provider = .claude) -> WidgetEntry {
+        let fallbackWindowID: UsageWindowID = switch provider {
+        case .claude: "session"
+        case .codex: "codexFiveHour"
+        case .cursor: "cursor.monthly.requests"
+        case .openCode, .openCodeGo: "custom"
+        }
+        return WidgetEntry(
+            date: .now,
+            snapshots: [],
+            selection: UsageActivitySelection(provider: provider, windowID: fallbackWindowID)
+        )
     }
 }
 #endif

--- a/AgentUsageWidgets/Shared/WidgetDataManager.swift
+++ b/AgentUsageWidgets/Shared/WidgetDataManager.swift
@@ -11,8 +11,8 @@ import AgentUsageKit
 /// Manages shared data between the main app and widget extension via App Groups
 /// Uses AgentUsageKit's WidgetDataStorage for consistent data access
 enum WidgetDataManager {
-    /// Load snapshot from shared storage
-    static func load() -> UsageSnapshot? {
-        WidgetDataStorage.shared.load()
+    /// Load all provider snapshots from shared storage.
+    static func load() -> [ProviderUsageSnapshot] {
+        WidgetDataStorage.shared.loadProviderSnapshots()
     }
 }

--- a/AgentUsageWidgets/TimelineProvider.swift
+++ b/AgentUsageWidgets/TimelineProvider.swift
@@ -3,62 +3,38 @@
 //  AgentUsageWidgets
 //
 
+import AgentUsageKit
 import Foundation
 import WidgetKit
-import AgentUsageKit
 
 /// Shared timeline construction for the home-screen and lock-screen widgets.
-///
-/// The widget reads the snapshot macOS publishes to CloudKit rather than calling
-/// a provider API. That keeps the per-account rate limit safe (only the Mac talks
-/// to `/api/oauth/usage`) while making widget freshness independent of whether the
-/// iOS app has been launched — the App Group cache alone only ever changes when
-/// the app process runs, which is why widgets appeared to stop refreshing.
 enum WidgetTimelineLoader {
-    /// How long the widget waits for CloudKit before falling back to the cache.
-    /// Timeline providers are killed if they take too long, so bound the fetch.
     private static let fetchTimeout: Duration = .seconds(8)
-
-    /// Spacing between pre-rendered entries within one timeline.
     private static let entryStride: TimeInterval = 5 * 60
-
-    /// When WidgetKit should build the next timeline (and re-read CloudKit).
     private static let reloadInterval: TimeInterval = 30 * 60
-
-    /// Entries are emitted slightly past `reloadInterval` so a delayed reload does
-    /// not leave the widget rendering the final entry indefinitely.
     private static let entryHorizon: TimeInterval = 35 * 60
 
-    /// The freshest snapshot available, preferring the Mac's CloudKit record and
-    /// falling back to the App Group cache when iCloud is unavailable or empty.
-    ///
-    /// Returns `nil` when neither source has anything. The widget then renders
-    /// its no-data state rather than a fabricated one — showing invented
-    /// percentages here would be indistinguishable from real usage.
-    static func currentSnapshot() async -> UsageSnapshot? {
-        if let synced = await syncedSnapshot() {
-            // Cache it so the synchronous `placeholder`/`snapshot` paths render
-            // real data instantly and the widget survives an offline reload.
+    /// Prefer the complete Mac-published CloudKit payload, then fall back to the
+    /// provider-neutral App Group cache. A modern provider-only record must not
+    /// be combined with an older cached Claude snapshot.
+    static func currentSnapshots() async -> [ProviderUsageSnapshot] {
+        if let synced = await syncedPayload() {
             WidgetDataStorage.shared.save(synced)
-            return synced
+            return synced.providerSnapshots
         }
         return WidgetDataManager.load()
     }
 
-    /// One entry every `entryStride` so reset countdowns and pace-based status
-    /// advance between reloads. WidgetKit renders every entry when the timeline is
-    /// built, so each view must derive time-dependent values from `entry.date`
-    /// rather than `Date()`.
     static func timeline(
-        snapshot: UsageSnapshot?,
-        metric: MetricType,
+        snapshots: [ProviderUsageSnapshot],
+        selection: UsageActivitySelection?,
         from now: Date = .now
     ) -> Timeline<WidgetEntry> {
         let entries = stride(from: 0, through: entryHorizon, by: entryStride).map { offset in
             WidgetEntry(
                 date: now.addingTimeInterval(offset),
-                snapshot: snapshot,
-                metric: metric
+                snapshots: snapshots,
+                selection: selection
             )
         }
         return Timeline(
@@ -67,12 +43,14 @@ enum WidgetTimelineLoader {
         )
     }
 
-    /// `fetchLatest()` already swallows CloudKit errors, but it can still stall on a
-    /// bad network. Race it against a timeout so the provider always returns.
-    private static func syncedSnapshot() async -> UsageSnapshot? {
-        await withTaskGroup(of: UsageSnapshot?.self) { group in
+    private static func syncedPayload() async -> WidgetUsagePayload? {
+        await withTaskGroup(of: WidgetUsagePayload?.self) { group in
             group.addTask {
-                await UsageSyncService.shared.fetchLatest()?.snapshot
+                guard let synced = await UsageSyncService.shared.fetchLatest() else { return nil }
+                return WidgetUsagePayload(
+                    snapshot: synced.snapshot,
+                    providerSnapshots: synced.providerSnapshots
+                )
             }
             group.addTask {
                 try? await Task.sleep(for: fetchTimeout)
@@ -85,37 +63,46 @@ enum WidgetTimelineLoader {
     }
 }
 
-struct Provider: AppIntentTimelineProvider {
+struct HomeScreenTimelineProvider: AppIntentTimelineProvider {
     func placeholder(in context: Context) -> WidgetEntry {
-        // Synchronous, so the cache is the only source available here. Real
-        // cached numbers when we have them, an honest blank when we don't.
-        WidgetEntry(date: .now, snapshot: WidgetDataManager.load())
+        WidgetEntry(date: .now, snapshots: WidgetDataManager.load())
     }
 
     func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> WidgetEntry {
-        // The gallery/transient preview should be instant, so read the cache only.
-        WidgetEntry(date: .now, snapshot: WidgetDataManager.load(), metric: configuration.metric)
+        WidgetEntry(
+            date: .now,
+            snapshots: WidgetDataManager.load(),
+            selection: configuration.selection
+        )
     }
 
     func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<WidgetEntry> {
-        let snapshot = await WidgetTimelineLoader.currentSnapshot()
-        return WidgetTimelineLoader.timeline(snapshot: snapshot, metric: configuration.metric)
+        let snapshots = await WidgetTimelineLoader.currentSnapshots()
+        return WidgetTimelineLoader.timeline(
+            snapshots: snapshots,
+            selection: configuration.selection
+        )
     }
 }
 
-struct LockScreenProvider: AppIntentTimelineProvider {
+struct LockScreenTimelineProvider: AppIntentTimelineProvider {
     func placeholder(in context: Context) -> WidgetEntry {
-        // Synchronous, so the cache is the only source available here. Real
-        // cached numbers when we have them, an honest blank when we don't.
-        WidgetEntry(date: .now, snapshot: WidgetDataManager.load())
+        WidgetEntry(date: .now, snapshots: WidgetDataManager.load())
     }
 
     func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> WidgetEntry {
-        WidgetEntry(date: .now, snapshot: WidgetDataManager.load(), metric: configuration.metric)
+        WidgetEntry(
+            date: .now,
+            snapshots: WidgetDataManager.load(),
+            selection: configuration.selection
+        )
     }
 
     func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<WidgetEntry> {
-        let snapshot = await WidgetTimelineLoader.currentSnapshot()
-        return WidgetTimelineLoader.timeline(snapshot: snapshot, metric: configuration.metric)
+        let snapshots = await WidgetTimelineLoader.currentSnapshots()
+        return WidgetTimelineLoader.timeline(
+            snapshots: snapshots,
+            selection: configuration.selection
+        )
     }
 }

--- a/AgentUsageWidgets/Views/LargeWidgetView.swift
+++ b/AgentUsageWidgets/Views/LargeWidgetView.swift
@@ -14,14 +14,14 @@ struct LargeWidgetView: View {
         if !entry.availableWindows.isEmpty {
             content(for: entry.availableWindows)
         } else {
-            WidgetNoDataView(reason: entry.snapshot == nil ? .noData : .awaitingRefresh)
+            WidgetNoDataView(reason: entry.unavailableReason, provider: entry.provider)
         }
     }
 
     private func content(for windows: [UsageWindow]) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
-                WidgetProviderIdentity(provider: WidgetDesign.provider, font: .headline)
+                WidgetProviderIdentity(provider: entry.provider, font: .headline)
                 Spacer(minLength: 8)
                 WidgetFreshnessLabel(entry: entry, font: .caption)
             }

--- a/AgentUsageWidgets/Views/LockScreenWidgetView.swift
+++ b/AgentUsageWidgets/Views/LockScreenWidgetView.swift
@@ -17,7 +17,7 @@ struct LockScreenWidgetView: View {
         } else {
             // WidgetNoDataView switches on the same family, so each accessory
             // shape gets its own empty treatment.
-            WidgetNoDataView(reason: entry.unavailableReason)
+            WidgetNoDataView(reason: entry.unavailableReason, provider: entry.provider)
         }
     }
 
@@ -41,7 +41,7 @@ struct LockScreenWidgetView: View {
         let status = usage.status(from: entry.date)
 
         return Gauge(value: usage.normalized) {
-            Image(systemName: WidgetDesign.provider.iconName)
+            Image(systemName: entry.provider.iconName)
                 .font(.caption2)
         } currentValueLabel: {
             VStack(spacing: 0) {
@@ -55,7 +55,7 @@ struct LockScreenWidgetView: View {
         .tint(status.color)
         .widgetAccentable()
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(WidgetDesign.provider.displayName), \(entry.metric.displayName) usage")
+        .accessibilityLabel("\(entry.provider.displayName), \(usage.displayName) usage")
         .accessibilityValue(accessibilityValue(for: usage, status: status))
         .accessibilityHint(accessibilityHint(for: usage))
     }
@@ -70,11 +70,11 @@ struct LockScreenWidgetView: View {
 
         return VStack(alignment: .leading, spacing: 2) {
             HStack(spacing: 4) {
-                Label(WidgetDesign.provider.displayName, systemImage: WidgetDesign.provider.iconName)
+                Label(entry.provider.displayName, systemImage: entry.provider.iconName)
                     .font(.caption)
                     .fontWeight(.semibold)
                     .lineLimit(1)
-                Text(entry.metric.displayName)
+                Text(usage.displayName)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -108,7 +108,7 @@ struct LockScreenWidgetView: View {
             .font(.caption2)
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(WidgetDesign.provider.displayName), \(entry.metric.displayName) usage")
+        .accessibilityLabel("\(entry.provider.displayName), \(usage.displayName) usage")
         .accessibilityValue(accessibilityValue(for: usage, status: status))
         .accessibilityHint(accessibilityHint(for: usage))
     }
@@ -118,9 +118,9 @@ struct LockScreenWidgetView: View {
     private func inlineView(for usage: UsageWindow) -> some View {
         let status = usage.status(from: entry.date)
 
-        return Text("\(Image(systemName: WidgetDesign.provider.iconName)) \(WidgetDesign.provider.displayName) \(usage.percentUsed)% \(Image(systemName: status.icon))")
+        return Text("\(Image(systemName: entry.provider.iconName)) \(entry.provider.displayName) \(usage.percentUsed)% \(Image(systemName: status.icon))")
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(WidgetDesign.provider.displayName), \(entry.metric.displayName) usage")
+        .accessibilityLabel("\(entry.provider.displayName), \(usage.displayName) usage")
         .accessibilityValue(accessibilityValue(for: usage, status: status))
         .accessibilityHint(accessibilityHint(for: usage))
     }

--- a/AgentUsageWidgets/Views/MediumWidgetView.swift
+++ b/AgentUsageWidgets/Views/MediumWidgetView.swift
@@ -14,14 +14,14 @@ struct MediumWidgetView: View {
         if !entry.availableWindows.isEmpty {
             content(for: Array(entry.availableWindows.prefix(2)))
         } else {
-            WidgetNoDataView(reason: entry.snapshot == nil ? .noData : .awaitingRefresh)
+            WidgetNoDataView(reason: entry.unavailableReason, provider: entry.provider)
         }
     }
 
     private func content(for windows: [UsageWindow]) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
-                WidgetProviderIdentity(provider: WidgetDesign.provider, font: .headline)
+                WidgetProviderIdentity(provider: entry.provider, font: .headline)
                 Spacer(minLength: 8)
                 WidgetFreshnessLabel(entry: entry)
             }

--- a/AgentUsageWidgets/Views/SmallWidgetView.swift
+++ b/AgentUsageWidgets/Views/SmallWidgetView.swift
@@ -14,7 +14,7 @@ struct SmallWidgetView: View {
         if let usage = entry.selectedWindow {
             content(for: usage)
         } else {
-            WidgetNoDataView(reason: entry.unavailableReason)
+            WidgetNoDataView(reason: entry.unavailableReason, provider: entry.provider)
         }
     }
 
@@ -25,9 +25,9 @@ struct SmallWidgetView: View {
         let resetText = usage.resetDescription(from: entry.date)
 
         return VStack(alignment: .leading, spacing: 8) {
-            WidgetProviderIdentity(provider: WidgetDesign.provider, font: .caption)
+            WidgetProviderIdentity(provider: entry.provider, font: .caption)
             WidgetUsageRow(
-                title: entry.metric.displayName,
+                title: usage.displayName,
                 usage: usage,
                 now: entry.date
             )
@@ -36,7 +36,7 @@ struct SmallWidgetView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(WidgetDesign.provider.displayName), \(entry.metric.displayName) usage")
+        .accessibilityLabel("\(entry.provider.displayName), \(usage.displayName) usage")
         .accessibilityValue(accessibilityValue(for: usage, status: status))
         .accessibilityHint("\(resetText). Updated \(entry.lastUpdatedDescription)")
     }
@@ -57,8 +57,8 @@ struct SmallWidgetView: View {
 #Preview("Small", as: .systemSmall) {
     AgentUsageWidgets()
 } timeline: {
-    WidgetEntry.preview(metric: .session)
-    WidgetEntry.preview(metric: .opus)
+    WidgetEntry.preview(provider: .claude)
+    WidgetEntry.preview(provider: .codex)
 }
 
 #Preview("Small — No data", as: .systemSmall) {

--- a/AgentUsageWidgets/Views/WidgetNoDataView.swift
+++ b/AgentUsageWidgets/Views/WidgetNoDataView.swift
@@ -13,11 +13,11 @@ struct WidgetNoDataView: View {
     @Environment(\.widgetFamily) private var family
 
     let reason: WidgetUnavailableReason
-    var provider: AgentUsageKit.Provider = WidgetDesign.provider
+    let provider: AgentUsageKit.Provider
 
     init(
         reason: WidgetUnavailableReason = .noData,
-        provider: AgentUsageKit.Provider = WidgetDesign.provider
+        provider: AgentUsageKit.Provider
     ) {
         self.reason = reason
         self.provider = provider
@@ -132,11 +132,11 @@ struct WidgetNoDataView: View {
                 hint: "Open Agent Usage on your Mac",
                 iconName: "chart.bar.xaxis"
             )
-        case .metricUnavailable:
+        case .windowUnavailable:
             WidgetUnavailableCopy(
-                title: "Metric unavailable",
-                inlineTitle: "metric unavailable",
-                hint: "Choose another metric",
+                title: "Window unavailable",
+                inlineTitle: "window unavailable",
+                hint: "Choose another usage window",
                 iconName: "questionmark.circle"
             )
         case .awaitingRefresh:

--- a/AgentUsageWidgets/Views/WidgetUsageComponents.swift
+++ b/AgentUsageWidgets/Views/WidgetUsageComponents.swift
@@ -9,10 +9,6 @@ import AgentUsageKit
 import SwiftUI
 import WidgetKit
 
-enum WidgetDesign {
-    static let provider: AgentUsageKit.Provider = .claude
-}
-
 /// Uses the provider-card tint and border as the widget's root chrome. WidgetKit
 /// supplies the outer shape and content margins, so the content does not create
 /// a nested card of its own.

--- a/AgentUsageWidgets/WidgetEntry.swift
+++ b/AgentUsageWidgets/WidgetEntry.swift
@@ -3,91 +3,96 @@
 //  AgentUsageWidgets
 //
 
+import AgentUsageKit
 import Foundation
 import WidgetKit
-import AgentUsageKit
 
 struct WidgetEntry: TimelineEntry {
     let date: Date
-    /// `nil` when neither CloudKit nor the App Group cache has a snapshot yet.
-    /// The widget renders `WidgetNoDataView` rather than inventing numbers —
-    /// a usage figure the user cannot act on is worse than an honest blank.
-    let snapshot: UsageSnapshot?
-    let metric: MetricType
+    let provider: AgentUsageKit.Provider
+    let providerSnapshot: ProviderUsageSnapshot?
+    let selection: UsageActivitySelection?
 
-    /// How old the Mac-published snapshot may be before the widget flags it.
-    /// Sits just past one full reload cycle (30 min), so a healthy chain — Mac
-    /// awake and publishing — never trips it, while a sleeping Mac shows up fast.
+    /// How old the selected provider's snapshot may be before the widget flags it.
     private static let staleThreshold: TimeInterval = 45 * 60
 
-    init(date: Date, snapshot: UsageSnapshot?, metric: MetricType = .session) {
+    private static let supportedProviders: [AgentUsageKit.Provider] = [
+        .claude,
+        .codex,
+        .cursor,
+    ]
+
+    init(
+        date: Date,
+        snapshots: [ProviderUsageSnapshot],
+        selection: UsageActivitySelection? = nil
+    ) {
         self.date = date
-        self.snapshot = snapshot
-        self.metric = metric
+        let resolvedSelection = selection ?? Self.defaultSelection(in: snapshots)
+        let resolvedProvider = resolvedSelection?.provider ?? .claude
+        self.selection = resolvedSelection
+        provider = resolvedProvider
+        providerSnapshot = snapshots.first { $0.provider == resolvedProvider }
     }
 
     var selectedWindow: UsageWindow? {
-        guard let snapshot else { return nil }
-        let window: UsageWindow?
-        switch metric {
-        case .session:
-            window = snapshot.session
-        case .opus:
-            window = snapshot.opus
-        case .sonnet:
-            window = snapshot.sonnet
-        case .design:
-            window = snapshot.design
-        case .fable:
-            window = snapshot.fable
+        guard let providerSnapshot, let selection else { return nil }
+        guard let window = providerSnapshot.windows.first(where: { $0.windowID == selection.windowID }),
+              !window.isExpired(from: date) else {
+            return nil
         }
-        guard let window, !window.isExpired(from: date) else { return nil }
         return window
     }
 
-    /// Non-expired windows in the same order as the iOS provider card.
+    /// Non-expired windows in the provider's published order.
     var availableWindows: [UsageWindow] {
-        guard let snapshot else { return [] }
-        return [snapshot.session, snapshot.opus, snapshot.sonnet, snapshot.design, snapshot.fable]
-            .compactMap { $0 }
-            .filter { !$0.isExpired(from: date) }
+        providerSnapshot?.windows.filter { !$0.isExpired(from: date) } ?? []
     }
 
     /// Why a selected or summary presentation has no trustworthy value.
     var unavailableReason: WidgetUnavailableReason {
-        guard let snapshot else { return .noData }
-
-        let configuredWindow: UsageWindow?
-        switch metric {
-        case .session: configuredWindow = snapshot.session
-        case .opus: configuredWindow = snapshot.opus
-        case .sonnet: configuredWindow = snapshot.sonnet
-        case .design: configuredWindow = snapshot.design
-        case .fable: configuredWindow = snapshot.fable
+        guard let providerSnapshot else { return .noData }
+        guard let selection,
+              let configuredWindow = providerSnapshot.windows.first(where: { $0.windowID == selection.windowID }) else {
+            return providerSnapshot.windows.isEmpty ? .noData : .windowUnavailable
         }
-
-        guard let configuredWindow else { return .metricUnavailable }
         return configuredWindow.isExpired(from: date) ? .awaitingRefresh : .noData
     }
 
-    /// Relative age of the data, measured from this entry's render time rather
-    /// than `Date()` — every entry in a timeline is rendered up front.
     var lastUpdatedDescription: String {
-        snapshot?.lastUpdatedDescription(asOf: date) ?? "never"
+        guard let providerSnapshot else { return "never" }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: providerSnapshot.fetchedAt, relativeTo: date)
     }
 
-    /// The Mac has not published in a while, so the numbers on screen are frozen
-    /// rather than simply unchanged. Never true without a snapshot: the no-data
-    /// state already says the widget is empty, so flagging it stale as well
-    /// would double up on the same message.
     var isStale: Bool {
-        guard let snapshot else { return false }
-        return snapshot.age(asOf: date) > Self.staleThreshold
+        guard let providerSnapshot else { return false }
+        return date.timeIntervalSince(providerSnapshot.fetchedAt) > Self.staleThreshold
+    }
+
+    private static func defaultSelection(
+        in snapshots: [ProviderUsageSnapshot]
+    ) -> UsageActivitySelection? {
+        if let claude = snapshots.first(where: { $0.provider == .claude }),
+           let window = claude.windows.first(where: { $0.windowID.rawValue == UsageWindowType.session.rawValue })
+            ?? claude.windows.first {
+            return UsageActivitySelection(provider: .claude, windowID: window.windowID)
+        }
+
+        for provider in supportedProviders where provider != .claude {
+            guard let snapshot = snapshots.first(where: { $0.provider == provider }),
+                  let window = snapshot.windows.first else {
+                continue
+            }
+            return UsageActivitySelection(provider: provider, windowID: window.windowID)
+        }
+        return nil
     }
 }
 
 enum WidgetUnavailableReason {
     case noData
-    case metricUnavailable
+    case windowUnavailable
     case awaitingRefresh
 }


### PR DESCRIPTION
## Summary

- Store and load provider-neutral widget payloads with legacy Claude migration
- Support configurable Claude, Codex, and Cursor usage windows
- Refresh widgets using all available provider snapshots
- Preserve compatibility with existing widget configurations and storage

## Testing

- Not run (not requested)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tartinerlabs/codesmith/AgentUsage/pr/97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788186554&installation_model_id=427837&pr_number=97&repository=tartinerlabs%2FAgentUsage&return_to=https%3A%2F%2Fgithub.com%2Ftartinerlabs%2FAgentUsage%2Fpull%2F97&signature=bff7bfca68443be79e092aa5c6c3e05e83b82b804de21fe678270ebe553d5ca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->